### PR TITLE
Don't hash files after downloading for which remote XML is available

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -667,7 +667,7 @@ void Downloader::download()
                     if (!games[i].extras[j].name.empty())
                         std::cout << "Dowloading: " << games[i].extras[j].name << std::endl;
                     std::cout << filepath << std::endl;
-                    CURLcode result = downloadFile(url, filepath);
+                    CURLcode result = this->downloadFile(url, filepath);
                     std::cout << std::endl;
                     if (result==CURLE_OK && config.sXMLFile == "automatic")
                     {
@@ -703,15 +703,8 @@ void Downloader::download()
                         XML = gogAPI->getXML(games[i].gamename, games[i].patches[j].id);
                     if (!games[i].patches[j].name.empty())
                         std::cout << "Dowloading: " << games[i].patches[j].name << std::endl;
-                    CURLcode result = this->downloadFile(url, filepath, XML, games[i].gamename);
+                    this->downloadFile(url, filepath, XML, games[i].gamename);
                     std::cout << std::endl;
-                    if (result==CURLE_OK && config.sXMLFile == "automatic" && XML.empty())
-                    {
-                        std::cout << "Starting automatic XML creation" << std::endl;
-                        std::string xml_dir = config.sXMLDirectory + "/" + games[i].gamename;
-                        Util::createXML(filepath, config.iChunkSize, xml_dir);
-                        std::cout << std::endl;
-                    }
                 }
             }
         }
@@ -740,15 +733,8 @@ void Downloader::download()
                     if (!games[i].languagepacks[j].name.empty())
                         std::cout << "Dowloading: " << games[i].gamename << " " << games[i].languagepacks[j].name << std::endl;
                     std::cout << filepath << std::endl;
-                    CURLcode result = downloadFile(url, filepath, XML, games[i].gamename);
+                    this->downloadFile(url, filepath, XML, games[i].gamename);
                     std::cout << std::endl;
-                    if (result==CURLE_OK && config.sXMLFile == "automatic")
-                    {
-                        std::cout << "Starting automatic XML creation" << std::endl;
-                        std::string xml_dir = config.sXMLDirectory + "/" + games[i].gamename;
-                        Util::createXML(filepath, config.iChunkSize, xml_dir);
-                        std::cout << std::endl;
-                    }
                 }
             }
         }
@@ -808,15 +794,8 @@ void Downloader::download()
                                 XML = gogAPI->getXML(games[i].dlcs[j].gamename, games[i].dlcs[j].patches[k].id);
                             if (!games[i].dlcs[j].patches[k].name.empty())
                                 std::cout << "Dowloading: " << games[i].dlcs[j].patches[k].name << std::endl;
-                            CURLcode result = this->downloadFile(url, filepath, XML, games[i].dlcs[j].gamename);
+                            this->downloadFile(url, filepath, XML, games[i].dlcs[j].gamename);
                             std::cout << std::endl;
-                            if (result==CURLE_OK && config.sXMLFile == "automatic" && XML.empty())
-                            {
-                                std::cout << "Starting automatic XML creation" << std::endl;
-                                std::string xml_dir = config.sXMLDirectory + "/" + games[i].dlcs[j].gamename;
-                                Util::createXML(filepath, config.iChunkSize, xml_dir);
-                                std::cout << std::endl;
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
downloadFile saves the remote XML, meaning that rehashing the file is not necessary. Only extras need the if-block, since they don't have remote XML.

I also changed all uses of downloadFile in download() to this->downloadFile, since there were calls with and without this->. With this-> seemed to be more frequent.
