### PR TITLE
Easier packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ clean_release:
 	rm -rf $(OBJDIR_RELEASE)/src
 	rm -f $(MAN_DIR)/$(MAN_PAGE) $(MAN_DIR)/$(MAN_PAGE).gz
 
-install:
+install: release
 	mkdir -p $(DESTDIR)/usr/bin
 	install $(OUT_RELEASE) $(DESTDIR)/usr/bin
 	if test -f $(MAN_DIR)/$(MAN_PAGE).gz; then \


### PR DESCRIPTION
When packaging for Linux distributions there are different approaches. For example running the `make install` command in a fakeroot environment that writes the files in a package instead of the filesystem, for this, the current install target works.
For Arch Linux (and probably others) we use a directory where all files get copied to and package that.

This addition allows setting the directory to install the directory structure to and is well known for [autotools](https://www.gnu.org/software/automake/manual/html_node/DESTDIR.html) and [cmake-based](http://www.cmake.org/Wiki/CMake_FAQ#Does_CMake.27s_.22make_install.22_support_DESTDIR.3F) projects.

Another small addition is an explicit dependency, it only install files when they have been built before.
