### PR TITLE
Fix status, download and repair for files > 2 GB on 32 bit platforms

### DIFF
--- a/include/downloader.h
+++ b/include/downloader.h
@@ -99,9 +99,9 @@ class Downloader
         void saveSerials(const std::string& serials, const std::string& filepath);
 
         static int progressCallback(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
-        static uintmax_t writeMemoryCallback(char *ptr, uintmax_t size, uintmax_t nmemb, void *userp);
-        static uintmax_t writeData(void *ptr, uintmax_t size, uintmax_t nmemb, FILE *stream);
-        static uintmax_t readData(void *ptr, uintmax_t size, uintmax_t nmemb, FILE *stream);
+        static size_t writeMemoryCallback(char *ptr, size_t size, size_t nmemb, void *userp);
+        static size_t writeData(void *ptr, size_t size, size_t nmemb, FILE *stream);
+        static size_t readData(void *ptr, size_t size, size_t nmemb, FILE *stream);
 
 
         API *gogAPI;
@@ -109,7 +109,7 @@ class Downloader
         std::vector<gameDetails> games;
         std::string coverXML;
 
-        uintmax_t resume_position;
+        off_t resume_position;
         int retries;
         std::ofstream report_ofs;
 };

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -74,7 +74,7 @@ class Downloader
         Timer timer;
         Config config;
         ProgressBar* progressbar;
-        std::deque< std::pair<time_t, size_t> > TimeAndSize;
+        std::deque< std::pair<time_t, uintmax_t> > TimeAndSize;
     protected:
     private:
         CURLcode downloadFile(const std::string& url, const std::string& filepath, const std::string& xml_data = std::string(), const std::string& gamename = std::string());
@@ -82,7 +82,7 @@ class Downloader
         int downloadCovers(const std::string& gamename, const std::string& directory, const std::string& cover_xml_data);
         int getGameDetails();
         void getGameList();
-        size_t getResumePosition();
+        uintmax_t getResumePosition();
         CURLcode beginDownload();
         std::string getResponse(const std::string& url);
         std::string getLocalFileHash(const std::string& filepath, const std::string& gamename = std::string());
@@ -99,9 +99,9 @@ class Downloader
         void saveSerials(const std::string& serials, const std::string& filepath);
 
         static int progressCallback(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
-        static size_t writeMemoryCallback(char *ptr, size_t size, size_t nmemb, void *userp);
-        static size_t writeData(void *ptr, size_t size, size_t nmemb, FILE *stream);
-        static size_t readData(void *ptr, size_t size, size_t nmemb, FILE *stream);
+        static uintmax_t writeMemoryCallback(char *ptr, uintmax_t size, uintmax_t nmemb, void *userp);
+        static uintmax_t writeData(void *ptr, uintmax_t size, uintmax_t nmemb, FILE *stream);
+        static uintmax_t readData(void *ptr, uintmax_t size, uintmax_t nmemb, FILE *stream);
 
 
         API *gogAPI;
@@ -109,7 +109,7 @@ class Downloader
         std::vector<gameDetails> games;
         std::string coverXML;
 
-        size_t resume_position;
+        uintmax_t resume_position;
         int retries;
         std::ofstream report_ofs;
 };

--- a/include/util.h
+++ b/include/util.h
@@ -32,7 +32,7 @@ namespace Util
     std::string makeFilepath(const std::string& directory, const std::string& path, const std::string& gamename, std::string subdirectory = "", const unsigned int& platformId = 0, const std::string& dlcname = "");
     std::string makeRelativeFilepath(const std::string& path, const std::string& gamename, std::string subdirectory = "");
     std::string getFileHash(const std::string& filename, unsigned hash_id);
-    std::string getChunkHash(unsigned char* chunk, size_t chunk_size, unsigned hash_id);
+    std::string getChunkHash(unsigned char* chunk, uintmax_t chunk_size, unsigned hash_id);
     int createXML(std::string filepath, size_t chunk_size, std::string xml_dir = std::string());
     int getGameSpecificConfig(std::string gamename, gameSpecificConfig* conf, std::string directory = std::string());
     int replaceString(std::string& str, const std::string& to_replace, const std::string& replace_with);

--- a/include/util.h
+++ b/include/util.h
@@ -33,7 +33,7 @@ namespace Util
     std::string makeRelativeFilepath(const std::string& path, const std::string& gamename, std::string subdirectory = "");
     std::string getFileHash(const std::string& filename, unsigned hash_id);
     std::string getChunkHash(unsigned char* chunk, uintmax_t chunk_size, unsigned hash_id);
-    int createXML(std::string filepath, size_t chunk_size, std::string xml_dir = std::string());
+    int createXML(std::string filepath, uintmax_t chunk_size, std::string xml_dir = std::string());
     int getGameSpecificConfig(std::string gamename, gameSpecificConfig* conf, std::string directory = std::string());
     int replaceString(std::string& str, const std::string& to_replace, const std::string& replace_with);
     void filepathReplaceReservedStrings(std::string& str, const std::string& gamename, const unsigned int& platformId = 0, const std::string& dlcname = "");

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -22,7 +22,7 @@
 
 size_t writeMemoryCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
     std::ostringstream *stream = (std::ostringstream*)userp;
-    size_t count = size * nmemb;
+    std::streamsize count = (std::streamsize) size * nmemb;
     stream->write(ptr, count);
     return count;
 }

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -1158,7 +1158,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
     CURLcode res = CURLE_RECV_ERROR; // assume network error
     bool bResume = false;
     FILE *outfile;
-    uintmax_t offset=0;
+    off_t offset=0;
 
     // Get directory from filepath
     boost::filesystem::path pathname = filepath;
@@ -1225,7 +1225,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
             {
                 bResume = true;
                 fseek(outfile, 0, SEEK_END);
-                offset = ftell(outfile);
+                offset = ftello(outfile);
                 curl_easy_setopt(curlhandle, CURLOPT_RESUME_FROM_LARGE, offset);
                 this->resume_position = offset;
             }
@@ -1870,19 +1870,19 @@ int Downloader::progressCallback(void *clientp, double dltotal, double dlnow, do
     return 0;
 }
 
-uintmax_t Downloader::writeMemoryCallback(char *ptr, uintmax_t size, uintmax_t nmemb, void *userp) {
+size_t Downloader::writeMemoryCallback(char *ptr, size_t size, size_t nmemb, void *userp) {
     std::ostringstream *stream = (std::ostringstream*)userp;
-    uintmax_t count = size * nmemb;
+    size_t count = size * nmemb;
     stream->write(ptr, count);
     return count;
 }
 
-uintmax_t Downloader::writeData(void *ptr, uintmax_t size, uintmax_t nmemb, FILE *stream)
+size_t Downloader::writeData(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
     return fwrite(ptr, size, nmemb, stream);
 }
 
-uintmax_t Downloader::readData(void *ptr, uintmax_t size, uintmax_t nmemb, FILE *stream)
+size_t Downloader::readData(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
     return fread(ptr, size, nmemb, stream);
 }

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -2593,7 +2593,7 @@ void Downloader::checkStatus()
                 std::string remoteHash;
                 std::string localHash;
                 bool bHashOK = true; // assume hash OK
-                size_t filesize;
+                uintmax_t filesize;
 
                 localHash = this->getLocalFileHash(filepath.string(), games[i].gamename);
                 remoteHash = this->getRemoteFileHash(games[i].gamename, games[i].installers[j].id);
@@ -2608,7 +2608,7 @@ void Downloader::checkStatus()
                     {
                         // Check for incomplete file by comparing the filesizes
                         // Remote hash was saved but download was incomplete and therefore getLocalFileHash returned the same as getRemoteFileHash
-                        size_t filesize_xml = 0;
+                        uintmax_t filesize_xml = 0;
                         boost::filesystem::path path = filepath;
                         boost::filesystem::path local_xml_file;
                         if (!games[i].gamename.empty())
@@ -2653,7 +2653,7 @@ void Downloader::checkStatus()
                 boost::filesystem::path filepath = games[i].extras[j].getFilepath();
 
                 std::string localHash = this->getLocalFileHash(filepath.string(), games[i].gamename);
-                size_t filesize;
+                uintmax_t filesize;
 
                 if (boost::filesystem::exists(filepath) && boost::filesystem::is_regular_file(filepath))
                 {
@@ -2674,7 +2674,7 @@ void Downloader::checkStatus()
                 boost::filesystem::path filepath = games[i].patches[j].getFilepath();
 
                 std::string localHash = this->getLocalFileHash(filepath.string(), games[i].gamename);
-                size_t filesize;
+                uintmax_t filesize;
 
                 if (boost::filesystem::exists(filepath) && boost::filesystem::is_regular_file(filepath))
                 {
@@ -2695,7 +2695,7 @@ void Downloader::checkStatus()
                 boost::filesystem::path filepath = games[i].languagepacks[j].getFilepath();
 
                 std::string localHash = this->getLocalFileHash(filepath.string(), games[i].gamename);
-                size_t filesize;
+                uintmax_t filesize;
 
                 if (boost::filesystem::exists(filepath) && boost::filesystem::is_regular_file(filepath))
                 {
@@ -2722,7 +2722,7 @@ void Downloader::checkStatus()
                         std::string remoteHash;
                         std::string localHash;
                         bool bHashOK = true; // assume hash OK
-                        size_t filesize;
+                        uintmax_t filesize;
 
                         localHash = this->getLocalFileHash(filepath.string(), games[i].dlcs[j].gamename);
                         remoteHash = this->getRemoteFileHash(games[i].dlcs[j].gamename, games[i].dlcs[j].installers[k].id);
@@ -2737,7 +2737,7 @@ void Downloader::checkStatus()
                             {
                                 // Check for incomplete file by comparing the filesizes
                                 // Remote hash was saved but download was incomplete and therefore getLocalFileHash returned the same as getRemoteFileHash
-                                size_t filesize_xml = 0;
+                                uintmax_t filesize_xml = 0;
                                 boost::filesystem::path path = filepath;
                                 boost::filesystem::path local_xml_file;
                                 if (!games[i].dlcs[j].gamename.empty())
@@ -2782,7 +2782,7 @@ void Downloader::checkStatus()
                         boost::filesystem::path filepath = games[i].dlcs[j].patches[k].getFilepath();
 
                         std::string localHash = this->getLocalFileHash(filepath.string(), games[i].dlcs[j].gamename);
-                        size_t filesize;
+                        uintmax_t filesize;
 
                         if (boost::filesystem::exists(filepath) && boost::filesystem::is_regular_file(filepath))
                         {
@@ -2803,7 +2803,7 @@ void Downloader::checkStatus()
                         boost::filesystem::path filepath = games[i].dlcs[j].extras[k].getFilepath();
 
                         std::string localHash = this->getLocalFileHash(filepath.string(), games[i].dlcs[j].gamename);
-                        size_t filesize;
+                        uintmax_t filesize;
 
                         if (boost::filesystem::exists(filepath) && boost::filesystem::is_regular_file(filepath))
                         {

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -1804,9 +1804,9 @@ int Downloader::progressCallback(void *clientp, double dltotal, double dlnow, do
         {
             downloader->TimeAndSize.pop_front();
             time_t time_first = downloader->TimeAndSize.front().first;
-            size_t size_first = downloader->TimeAndSize.front().second;
+            uintmax_t size_first = downloader->TimeAndSize.front().second;
             time_t time_last = downloader->TimeAndSize.back().first;
-            size_t size_last = downloader->TimeAndSize.back().second;
+            uintmax_t size_last = downloader->TimeAndSize.back().second;
             rate = (size_last - size_first) / static_cast<double>((time_last - time_first));
         }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -71,7 +71,7 @@ std::string Util::getFileHash(const std::string& filename, unsigned hash_id)
     return result;
 }
 
-std::string Util::getChunkHash(unsigned char *chunk, size_t chunk_size, unsigned hash_id)
+std::string Util::getChunkHash(unsigned char *chunk, uintmax_t chunk_size, unsigned hash_id)
 {
     unsigned char digest[rhash_get_digest_size(hash_id)];
     char result[rhash_get_hash_length(hash_id)];
@@ -87,12 +87,12 @@ std::string Util::getChunkHash(unsigned char *chunk, size_t chunk_size, unsigned
 }
 
 // Create GOG XML
-int Util::createXML(std::string filepath, size_t chunk_size, std::string xml_dir)
+int Util::createXML(std::string filepath, uintmax_t chunk_size, std::string xml_dir)
 {
     int res = 0;
     FILE *infile;
     FILE *xmlfile;
-    size_t filesize, size;
+    uintmax_t filesize, size;
     int chunks, i;
 
     if (xml_dir.empty())
@@ -158,11 +158,11 @@ int Util::createXML(std::string filepath, size_t chunk_size, std::string xml_dir
     char rhash_result[rhash_get_hash_length(RHASH_MD5)];
 
     for (i = 0; i < chunks; i++) {
-        size_t range_begin = i*chunk_size;
+        uintmax_t range_begin = i*chunk_size;
         fseek(infile, range_begin, SEEK_SET);
         if ((i == chunks-1) && (remaining != 0))
             chunk_size = remaining;
-        size_t range_end = range_begin + chunk_size - 1;
+        uintmax_t range_end = range_begin + chunk_size - 1;
         unsigned char *chunk = (unsigned char *) malloc(chunk_size * sizeof(unsigned char *));
         if (chunk == NULL)
         {


### PR DESCRIPTION
Fixed and tested status-checking, downloading and repairing large files (size > 2 GB) on 32 bit platforms (tested on arm7hf).

Changes fall into two categories:
 * use 8 byte int data types where necessary. The actual data types have been chosen depending on the library function they are used with.
 * replace some file handling functions with their large file counterparts

Fixes [issue 54](https://github.com/Sude-/lgogdownloader/issues/54).