### PR TITLE
Add output filename option

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -68,6 +68,7 @@ class Config
         std::string sDLCSubdir;
         std::string sGameSubdir;
         std::string sFileIdString;
+        std::string sOutputFilename;
         std::string sLanguagePriority;
         std::string sPlatformPriority;
         std::string sIgnoreDLCCountRegex;

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -68,7 +68,7 @@ class Downloader
         void checkOrphans();
         void checkStatus();
         void updateCache();
-        void downloadFileWithId(const std::string& fileid_string);
+        void downloadFileWithId(const std::string& fileid_string, const std::string& output_filepath);
         void showWishlist();
         CURL* curlhandle;
         Timer timer;

--- a/main.cpp
+++ b/main.cpp
@@ -150,6 +150,7 @@ int main(int argc, char *argv[])
             ("update-cache", bpo::value<bool>(&config.bUpdateCache)->zero_tokens()->default_value(false), "Update game details cache")
             ("no-platform-detection", bpo::value<bool>(&bNoPlatformDetection)->zero_tokens()->default_value(false), "Don't try to detect supported platforms from game shelf.\nSkips the initial fast platform detection and detects the supported platforms from game details which is slower but more accurate.\nUseful in case platform identifier is missing for some games in the game shelf.\nUsing --platform with --list doesn't work with this option.")
             ("download-file", bpo::value<std::string>(&config.sFileIdString)->default_value(""), "Download a single file using fileid\nFormat: \"gamename/fileid\"\nThis option ignores all subdir options. The file is downloaded to directory specified with --directory option.")
+            ("output-file,o", bpo::value<std::string>(&config.sOutputFilename)->default_value(""), "Set filename of file downloaded with --download-file.")
             ("wishlist", bpo::value<bool>(&config.bShowWishlist)->zero_tokens()->default_value(false), "Show wishlist")
             ("login-api", bpo::value<bool>(&config.bLoginAPI)->zero_tokens()->default_value(false), "Login (API only)")
             ("login-website", bpo::value<bool>(&config.bLoginHTTP)->zero_tokens()->default_value(false), "Login (website only)")
@@ -510,7 +511,7 @@ int main(int argc, char *argv[])
     else if (config.bUpdateCheck) // Update check has priority over download and list
         downloader.updateCheck();
     else if (!config.sFileIdString.empty())
-        downloader.downloadFileWithId(config.sFileIdString);
+        downloader.downloadFileWithId(config.sFileIdString, config.sOutputFilename);
     else if (config.bRepair) // Repair file
         downloader.repair();
     else if (config.bDownload) // Download games

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -1174,6 +1174,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
 
     // Get directory from filepath
     boost::filesystem::path pathname = filepath;
+    pathname = boost::filesystem::absolute(pathname, boost::filesystem::current_path());
     std::string directory = pathname.parent_path().string();
     std::string filenameXML = pathname.filename().string() + ".xml";
     std::string xml_directory;
@@ -3174,12 +3175,16 @@ void Downloader::saveSerials(const std::string& serials, const std::string& file
     return;
 }
 
-void Downloader::downloadFileWithId(const std::string& fileid_string)
+void Downloader::downloadFileWithId(const std::string& fileid_string, const std::string& output_filepath)
 {
     size_t pos = fileid_string.find("/");
     if (pos == std::string::npos)
     {
         std::cout << "Invalid file id " << fileid_string << ": could not find separator \"/\"" << std::endl;
+    }
+    else if (!output_filepath.empty() && boost::filesystem::is_directory(output_filepath))
+    {
+        std::cout << "Failed to create the file " << output_filepath << ": Is a directory" << std::endl;
     }
     else
     {
@@ -3198,7 +3203,10 @@ void Downloader::downloadFileWithId(const std::string& fileid_string)
         {
             std::string filename, filepath;
             filename.assign(url.begin()+url.find_last_of("/")+1, url.begin()+url.find_first_of("?"));
-            filepath = Util::makeFilepath(config.sDirectory, filename, gamename);
+            if (output_filepath.empty())
+                filepath = Util::makeFilepath(config.sDirectory, filename, gamename);
+            else
+                filepath = output_filepath;
             std::cout << "Downloading: " << filepath << std::endl;
             this->downloadFile(url, filepath, std::string(), gamename);
             std::cout << std::endl;


### PR DESCRIPTION
Add `-o --output-file` option to specify path and downloaded file name when using
`--download-file`
Overrides `--directory`

Bring lgogdownloader closer to command comparability with other command line downloaders such as curl and wget

Second step to Facilitating packaging scripting such as the [Arch User Repository](https://aur4.archlinux.org/packages/?K=gog-) by adding download agents and letting lgogdownloader do the authentication and download.

```bash
DLAGENTS+=('gogdownloader::/usr/bin/lgogdownloader -o %o %u')
source=("FILENAME::gogdownloader://GAME_NAME/FILE_ID")
```