### PR TITLE
Default login

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -491,7 +491,8 @@ int main(int argc, char *argv[])
             }
             ofs.close();
             Util::setFilePermissions(config.sConfigFilePath, boost::filesystem::owner_read | boost::filesystem::owner_write);
-            return 0;
+            if (config.bSaveConfig)
+                return 0;
         }
         else
         {
@@ -519,7 +520,7 @@ int main(int argc, char *argv[])
             return 1;
         }
     }
-    else if (config.bShowWishlist)
+    if (config.bShowWishlist)
         downloader.showWishlist();
     else if (config.bUpdateCache)
         downloader.updateCache();

--- a/main.cpp
+++ b/main.cpp
@@ -423,6 +423,8 @@ int main(int argc, char *argv[])
     int iLoginResult = 0;
     if (config.bLoginAPI || config.bLoginHTTP || initResult == 1)
     {
+        if (!config.bLoginAPI && !config.bLoginHTTP)
+            downloader.config.bLoginAPI = true;
         iLoginResult = downloader.login();
         if (iLoginResult == 0)
             return 1;


### PR DESCRIPTION
Fix issue with running `lgogdownloader gogdownloader://GAME/FILENAME` when config hasn't been created yet.
Prior to this, the command asks for username and password but does not save the configuration. It then neglects to download the file.
Allow downloading of files even if config is missing with only one prompt for username and password