### PR TITLE
Check that stdin is a tty before reading

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -121,6 +121,10 @@ int Downloader::login()
 {
     char *pwd;
     std::string email;
+    if (!isatty(STDIN_FILENO)) {
+        std::cout << "Unable to read email and password" << std::endl;
+        return 0;
+    }
     std::cout << "Email: ";
     std::getline(std::cin,email);
     pwd = getpass("Password: ");


### PR DESCRIPTION
If stdin isn't a tty, the behaviour of std::getline(std::cin, email) and getpass() is different (the latter always uses /dev/tty). If input is redirected, it's probably best to just fail.