### PR TITLE
Misc. changes

### DIFF
--- a/cmake/FindTinyxml.cmake
+++ b/cmake/FindTinyxml.cmake
@@ -6,7 +6,7 @@
 #  Tinyxml_LIBRARIES - The libraries needed to use tinyxml
 
 find_package(PkgConfig)
-pkg_check_modules(PC_TINYXML REQUIRED tinyxml)
+pkg_check_modules(PC_TINYXML tinyxml)
 
 find_path(TINYXML_INCLUDE_DIR tinyxml.h
   HINTS
@@ -26,8 +26,8 @@ find_library(TINYXML_LIBRARY tinyxml
 
 mark_as_advanced(TINYXML_INCLUDE_DIR TINYXML_LIBRARY)
 
-if(PC_TINYXML_FOUND)
+if(TINYXML_INCLUDE_DIR)
   set(Tinyxml_FOUND ON)
   set(Tinyxml_INCLUDE_DIRS ${TINYXML_INCLUDE_DIR})
   set(Tinyxml_LIBRARIES ${TINYXML_LIBRARY})
-endif(PC_TINYXML_FOUND)
+endif(TINYXML_INCLUDE_DIR)

--- a/include/api.h
+++ b/include/api.h
@@ -72,7 +72,7 @@ class API
         std::string getErrorMessage() { return this->error_message; };
         std::string getToken() { return this->config.oauth_token; };
         std::string getSecret() { return this->config.oauth_secret; };
-        template <typename T> CURLcode curlSetOpt(CURLoption option, T value) { return curl_easy_setopt(this->curlhandle, option, value); };
+        template <typename T> CURLcode curlSetOpt(CURLoption option, T value) { return curl_easy_setopt(this->curlhandle, option, value); }
         virtual ~API();
     protected:
     private:

--- a/include/config.h
+++ b/include/config.h
@@ -60,6 +60,7 @@ class Config
         std::string sCookiePath;
         std::string sConfigFilePath;
         std::string sBlacklistFilePath;
+        std::string sIgnorelistFilePath;
         std::string sOrphanRegex;
         std::string sCoverList;
         std::string sReportFilePath;
@@ -87,6 +88,7 @@ class Config
         curl_off_t iDownloadRate;
         long int iTimeout;
         Blacklist blacklist;
+        Blacklist ignorelist;
 };
 
 #endif // CONFIG_H__

--- a/include/globalconstants.h
+++ b/include/globalconstants.h
@@ -74,6 +74,6 @@ namespace GlobalConstants
         { PLATFORM_MAC,     "mac",   "Mac"     , "m|mac|osx"     },
         { PLATFORM_LINUX,   "linux", "Linux"   , "l|lin|linux"   }
     };
-};
+}
 
 #endif // GLOBALCONSTANTS_H_INCLUDED

--- a/main.cpp
+++ b/main.cpp
@@ -54,6 +54,7 @@ int main(int argc, char *argv[])
     config.sCookiePath = config.sConfigDirectory + "/cookies.txt";
     config.sConfigFilePath = config.sConfigDirectory + "/config.cfg";
     config.sBlacklistFilePath = config.sConfigDirectory + "/blacklist.txt";
+    config.sIgnorelistFilePath = config.sConfigDirectory + "/ignorelist.txt";
 
     std::string priority_help_text = "Set priority by separating values with \",\"\nCombine values by separating with \"+\"";
     // Create help text for --platform option
@@ -269,6 +270,27 @@ int main(int argc, char *argv[])
                     lines.push_back(std::move(line));
                 }
                 config.blacklist.initialize(lines);
+            }
+        }
+
+        if (boost::filesystem::exists(config.sIgnorelistFilePath))
+        {
+            std::ifstream ifs(config.sIgnorelistFilePath.c_str());
+            if (!ifs)
+            {
+                std::cerr << "Could not open ignorelist file: " << config.sIgnorelistFilePath << std::endl;
+                return 1;
+            }
+            else
+            {
+                std::string line;
+                std::vector<std::string> lines;
+                while (!ifs.eof())
+                {
+                    std::getline(ifs, line);
+                    lines.push_back(std::move(line));
+                }
+                config.ignorelist.initialize(lines);
             }
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -209,7 +209,7 @@ int main(int argc, char *argv[])
         {
             if (!boost::filesystem::create_directories(path))
             {
-                std::cout << "Failed to create directory: " << path << std::endl;
+                std::cerr << "Failed to create directory: " << path << std::endl;
                 return 1;
             }
         }
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
         {
             if (!boost::filesystem::create_directories(path))
             {
-                std::cout << "Failed to create directory: " << path << std::endl;
+                std::cerr << "Failed to create directory: " << path << std::endl;
                 return 1;
             }
         }
@@ -229,7 +229,7 @@ int main(int argc, char *argv[])
         {
             if (!boost::filesystem::create_directories(path))
             {
-                std::cout << "Failed to create directory: " << path << std::endl;
+                std::cerr << "Failed to create directory: " << path << std::endl;
                 return 1;
             }
         }
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
             std::ifstream ifs(config.sConfigFilePath.c_str());
             if (!ifs)
             {
-                std::cout << "Could not open config file: " << config.sConfigFilePath << std::endl;
+                std::cerr << "Could not open config file: " << config.sConfigFilePath << std::endl;
                 return 1;
             }
             else
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
             std::ifstream ifs(config.sBlacklistFilePath.c_str());
             if (!ifs)
             {
-                std::cout << "Could not open blacklist file: " << config.sBlacklistFilePath << std::endl;
+                std::cerr << "Could not open blacklist file: " << config.sBlacklistFilePath << std::endl;
                 return 1;
             }
             else
@@ -363,13 +363,13 @@ int main(int argc, char *argv[])
 
     if (config.iInstallerPlatform < GlobalConstants::PLATFORMS[0].id || config.iInstallerPlatform > platform_all)
     {
-        std::cout << "Invalid value for --platform" << std::endl;
+        std::cerr << "Invalid value for --platform" << std::endl;
         return 1;
     }
 
     if (config.iInstallerLanguage < GlobalConstants::LANGUAGES[0].id || config.iInstallerLanguage > language_all)
     {
-        std::cout << "Invalid value for --language" << std::endl;
+        std::cerr << "Invalid value for --language" << std::endl;
         return 1;
     }
 
@@ -435,7 +435,7 @@ int main(int argc, char *argv[])
         std::ofstream ofs(config.sConfigFilePath.c_str());
         if (ofs)
         {
-            std::cout << "Saving config: " << config.sConfigFilePath << std::endl;
+            std::cerr << "Saving config: " << config.sConfigFilePath << std::endl;
             for (bpo::variables_map::iterator it = vm.begin(); it != vm.end(); ++it)
             {
                 std::string option = it->first;
@@ -486,7 +486,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            std::cout << "Failed to create config: " << config.sConfigFilePath << std::endl;
+            std::cerr << "Failed to create config: " << config.sConfigFilePath << std::endl;
             return 1;
         }
     }
@@ -506,7 +506,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            std::cout << "Failed to create config: " << config.sConfigFilePath << std::endl;
+            std::cerr << "Failed to create config: " << config.sConfigFilePath << std::endl;
             return 1;
         }
     }
@@ -535,7 +535,7 @@ int main(int argc, char *argv[])
         downloader.checkStatus();
     else
     {   // Show help message
-        std::cout   << config.sVersionString << std::endl
+        std::cerr   << config.sVersionString << std::endl
                     << options_cli_all << std::endl;
     }
 

--- a/man/lgogdownloader.supplemental.groff
+++ b/man/lgogdownloader.supplemental.groff
@@ -62,7 +62,15 @@ If \fB$XDG_CACHE_HOME\fP is not set, it will use \fI$HOME/.cache/lgogdownloader/
 
 .TP
 \fI$XDG_CONFIG_HOME/lgogdownloader/blacklist.txt\fP
-Allows user to specify individual files that should not be downloaded or mentioned as orphans.
+Allows user to specify individual files that should not be downloaded.
+.br
+It doesn't have to exist, but if it does exist, it must be readable to lgogdownloader.
+
+.TP
+\fI$XDG_CONFIG_HOME/lgogdownloader/ignorelist.txt\fP
+Allows user to specify individual files that should not be mentioned
+as orphans.  The file has the same format and interpretation as a
+blacklist.
 .br
 It doesn't have to exist, but if it does exist, it must be readable to lgogdownloader.
 

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -32,7 +32,7 @@ Downloader::Downloader(Config &conf)
     this->config = conf;
     if (config.bLoginHTTP && boost::filesystem::exists(config.sCookiePath))
         if (!boost::filesystem::remove(config.sCookiePath))
-            std::cout << "Failed to delete " << config.sCookiePath << std::endl;
+            std::cerr << "Failed to delete " << config.sCookiePath << std::endl;
 }
 
 Downloader::~Downloader()
@@ -105,7 +105,7 @@ int Downloader::init()
         this->report_ofs.open(config.sReportFilePath);
         if (!this->report_ofs)
         {
-            std::cout << "Failed to create " << config.sReportFilePath << std::endl;
+            std::cerr << "Failed to create " << config.sReportFilePath << std::endl;
             return 1;
         }
     }
@@ -122,16 +122,16 @@ int Downloader::login()
     char *pwd;
     std::string email;
     if (!isatty(STDIN_FILENO)) {
-        std::cout << "Unable to read email and password" << std::endl;
+        std::cerr << "Unable to read email and password" << std::endl;
         return 0;
     }
-    std::cout << "Email: ";
+    std::cerr << "Email: ";
     std::getline(std::cin,email);
     pwd = getpass("Password: ");
     std::string password = (std::string)pwd;
     if (email.empty() || password.empty())
     {
-        std::cout << "Email and/or password empty" << std::endl;
+        std::cerr << "Email and/or password empty" << std::endl;
         return 0;
     }
     else
@@ -141,12 +141,12 @@ int Downloader::login()
         {
             if (!HTTP_Login(email, password))
             {
-                std::cout << "HTTP: Login failed" << std::endl;
+                std::cerr << "HTTP: Login failed" << std::endl;
                 return 0;
             }
             else
             {
-                std::cout << "HTTP: Login successful" << std::endl;
+                std::cerr << "HTTP: Login successful" << std::endl;
                 if (!config.bLoginAPI)
                     return 1;
             }
@@ -156,12 +156,12 @@ int Downloader::login()
         {
             if (!gogAPI->login(email, password))
             {
-                std::cout << "API: Login failed" << std::endl;
+                std::cerr << "API: Login failed" << std::endl;
                 return 0;
             }
             else
             {
-                std::cout << "API: Login successful" << std::endl;
+                std::cerr << "API: Login successful" << std::endl;
                 config.sToken = gogAPI->getToken();
                 config.sSecret = gogAPI->getSecret();
                 return 1;
@@ -227,7 +227,7 @@ int Downloader::getGameDetails()
         if (config.sGameRegex == "all")
             config.sGameRegex = ".*";
         else if (config.sGameRegex == "free")
-            std::cout << "Warning: regex alias \"free\" doesn't work with cached details" << std::endl;
+            std::cerr << "Warning: regex alias \"free\" doesn't work with cached details" << std::endl;
 
         int result = this->loadGameDetailsCache();
         if (result == 0)
@@ -245,13 +245,13 @@ int Downloader::getGameDetails()
         {
             if (result == 1)
             {
-                std::cout << "Cache doesn't exist." << std::endl;
-                std::cout << "Create cache with --update-cache" << std::endl;
+                std::cerr << "Cache doesn't exist." << std::endl;
+                std::cerr << "Create cache with --update-cache" << std::endl;
             }
             else if (result == 3)
             {
-                std::cout << "Cache is too old." << std::endl;
-                std::cout << "Update cache with --update-cache or use bigger --cache-valid" << std::endl;
+                std::cerr << "Cache is too old." << std::endl;
+                std::cerr << "Update cache with --update-cache or use bigger --cache-valid" << std::endl;
             }
             return 1;
         }
@@ -261,7 +261,7 @@ int Downloader::getGameDetails()
     int updated = 0;
     for (unsigned int i = 0; i < gameItems.size(); ++i)
     {
-        std::cout << "Getting game info " << i+1 << " / " << gameItems.size() << "\r" << std::flush;
+        std::cerr << "Getting game info " << i+1 << " / " << gameItems.size() << "\r" << std::flush;
         bool bHasDLC = !gameItems[i].dlcnames.empty();
 
         gameSpecificConfig conf;
@@ -277,31 +277,31 @@ int Downloader::getGameDetails()
             int iOptionsOverridden = Util::getGameSpecificConfig(gameItems[i].name, &conf);
             if (iOptionsOverridden > 0)
             {
-                std::cout << std::endl << gameItems[i].name << " - " << iOptionsOverridden << " options overridden with game specific options" << std::endl;
+                std::cerr << std::endl << gameItems[i].name << " - " << iOptionsOverridden << " options overridden with game specific options" << std::endl;
                 if (config.bVerbose)
                 {
                     if (conf.bIgnoreDLCCount)
-                        std::cout << "\tIgnore DLC count" << std::endl;
+                        std::cerr << "\tIgnore DLC count" << std::endl;
                     if (conf.bDLC != config.bDLC)
-                        std::cout << "\tDLC: " << (conf.bDLC ? "true" : "false") << std::endl;
+                        std::cerr << "\tDLC: " << (conf.bDLC ? "true" : "false") << std::endl;
                     if (conf.iInstallerLanguage != config.iInstallerLanguage)
-                        std::cout << "\tLanguage: " << Util::getOptionNameString(conf.iInstallerLanguage, GlobalConstants::LANGUAGES) << std::endl;
+                        std::cerr << "\tLanguage: " << Util::getOptionNameString(conf.iInstallerLanguage, GlobalConstants::LANGUAGES) << std::endl;
                     if (conf.vLanguagePriority != config.vLanguagePriority)
                     {
-                        std::cout << "\tLanguage priority:" << std::endl;
+                        std::cerr << "\tLanguage priority:" << std::endl;
                         for (unsigned int j = 0; j < conf.vLanguagePriority.size(); ++j)
                         {
-                            std::cout << "\t  " << j << ": " << Util::getOptionNameString(conf.vLanguagePriority[j], GlobalConstants::LANGUAGES) << std::endl;
+                            std::cerr << "\t  " << j << ": " << Util::getOptionNameString(conf.vLanguagePriority[j], GlobalConstants::LANGUAGES) << std::endl;
                         }
                     }
                     if (conf.iInstallerPlatform != config.iInstallerPlatform)
-                        std::cout << "\tPlatform: " << Util::getOptionNameString(conf.iInstallerPlatform, GlobalConstants::PLATFORMS) << std::endl;
+                        std::cerr << "\tPlatform: " << Util::getOptionNameString(conf.iInstallerPlatform, GlobalConstants::PLATFORMS) << std::endl;
                     if (conf.vPlatformPriority != config.vPlatformPriority)
                     {
-                        std::cout << "\tPlatform priority:" << std::endl;
+                        std::cerr << "\tPlatform priority:" << std::endl;
                         for (unsigned int j = 0; j < conf.vPlatformPriority.size(); ++j)
                         {
-                            std::cout << "\t  " << j << ": " << Util::getOptionNameString(conf.vPlatformPriority[j], GlobalConstants::PLATFORMS) << std::endl;
+                            std::cerr << "\t  " << j << ": " << Util::getOptionNameString(conf.vPlatformPriority[j], GlobalConstants::PLATFORMS) << std::endl;
                         }
                     }
                 }
@@ -411,19 +411,19 @@ int Downloader::getGameDetails()
                 }
                 if (updated >= gogAPI->user.notifications_games)
                 { // Gone through all updated games. No need to go through the rest.
-                    std::cout << std::endl << "Got info for all updated games. Moving on..." << std::endl;
+                    std::cerr << std::endl << "Got info for all updated games. Moving on..." << std::endl;
                     break;
                 }
             }
         }
         else
         {
-            std::cout << gogAPI->getErrorMessage() << std::endl;
+            std::cerr << gogAPI->getErrorMessage() << std::endl;
             gogAPI->clearError();
             continue;
         }
     }
-    std::cout << std::endl;
+    std::cerr << std::endl;
     return 0;
 }
 
@@ -454,7 +454,7 @@ void Downloader::listGames()
                         if (config.blacklist.isBlacklisted(filepath))
                         {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -480,7 +480,7 @@ void Downloader::listGames()
                     if (config.blacklist.isBlacklisted(filepath))
                     {
                         if (config.bVerbose)
-                            std::cout << "skipped blacklisted file " << filepath << std::endl;
+                            std::cerr << "skipped blacklisted file " << filepath << std::endl;
                         continue;
                     }
 
@@ -501,7 +501,7 @@ void Downloader::listGames()
                     if (config.blacklist.isBlacklisted(filepath))
                     {
                         if (config.bVerbose)
-                            std::cout << "skipped blacklisted file " << filepath << std::endl;
+                            std::cerr << "skipped blacklisted file " << filepath << std::endl;
                         continue;
                     }
 
@@ -526,7 +526,7 @@ void Downloader::listGames()
                     if (config.blacklist.isBlacklisted(filepath))
                     {
                         if (config.bVerbose)
-                            std::cout << "skipped blacklisted file " << filepath << std::endl;
+                            std::cerr << "skipped blacklisted file " << filepath << std::endl;
                         continue;
                     }
 
@@ -554,7 +554,7 @@ void Downloader::listGames()
                         if (config.blacklist.isBlacklisted(filepath))
                         {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -571,7 +571,7 @@ void Downloader::listGames()
                         std::string filepath = games[i].dlcs[j].patches[k].getFilepath();
                         if (config.blacklist.isBlacklisted(filepath)) {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -587,7 +587,7 @@ void Downloader::listGames()
                         std::string filepath = games[i].dlcs[j].extras[k].getFilepath();
                         if (config.blacklist.isBlacklisted(filepath)) {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -630,7 +630,7 @@ void Downloader::repair()
                 if (config.blacklist.isBlacklisted(filepath))
                 {
                     if (config.bVerbose)
-                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                        std::cerr << "skipped blacklisted file " << filepath << std::endl;
                     continue;
                 }
 
@@ -641,7 +641,7 @@ void Downloader::repair()
                     XML = gogAPI->getXML(games[i].gamename, games[i].installers[j].id);
                     if (gogAPI->getError())
                     {
-                        std::cout << gogAPI->getErrorMessage() << std::endl;
+                        std::cerr << gogAPI->getErrorMessage() << std::endl;
                         gogAPI->clearError();
                         continue;
                     }
@@ -654,7 +654,7 @@ void Downloader::repair()
                     std::string url = gogAPI->getInstallerLink(games[i].gamename, games[i].installers[j].id);
                     if (gogAPI->getError())
                     {
-                        std::cout << gogAPI->getErrorMessage() << std::endl;
+                        std::cerr << gogAPI->getErrorMessage() << std::endl;
                         gogAPI->clearError();
                         continue;
                     }
@@ -674,14 +674,14 @@ void Downloader::repair()
                 if (config.blacklist.isBlacklisted(filepath))
                 {
                     if (config.bVerbose)
-                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                        std::cerr << "skipped blacklisted file " << filepath << std::endl;
                     continue;
                 }
 
                 std::string url = gogAPI->getExtraLink(games[i].gamename, games[i].extras[j].id);
                 if (gogAPI->getError())
                 {
-                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                     gogAPI->clearError();
                     continue;
                 }
@@ -700,7 +700,7 @@ void Downloader::repair()
                 if (config.blacklist.isBlacklisted(filepath))
                 {
                     if (config.bVerbose)
-                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                        std::cerr << "skipped blacklisted file " << filepath << std::endl;
                     continue;
                 }
 
@@ -711,7 +711,7 @@ void Downloader::repair()
                     XML = gogAPI->getXML(games[i].gamename, games[i].patches[j].id);
                     if (gogAPI->getError())
                     {
-                        std::cout << gogAPI->getErrorMessage() << std::endl;
+                        std::cerr << gogAPI->getErrorMessage() << std::endl;
                         gogAPI->clearError();
                     }
                 }
@@ -719,7 +719,7 @@ void Downloader::repair()
                 std::string url = gogAPI->getPatchLink(games[i].gamename, games[i].patches[j].id);
                 if (gogAPI->getError())
                 {
-                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                     gogAPI->clearError();
                     continue;
                 }
@@ -738,14 +738,14 @@ void Downloader::repair()
                 if (config.blacklist.isBlacklisted(filepath))
                 {
                     if (config.bVerbose)
-                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                        std::cerr << "skipped blacklisted file " << filepath << std::endl;
                     continue;
                 }
 
                 std::string url = gogAPI->getLanguagePackLink(games[i].gamename, games[i].languagepacks[j].id);
                 if (gogAPI->getError())
                 {
-                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                     gogAPI->clearError();
                     continue;
                 }
@@ -766,7 +766,7 @@ void Downloader::repair()
                         if (config.blacklist.isBlacklisted(filepath))
                         {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -777,7 +777,7 @@ void Downloader::repair()
                             XML = gogAPI->getXML(games[i].dlcs[j].gamename, games[i].dlcs[j].installers[k].id);
                             if (gogAPI->getError())
                             {
-                                std::cout << gogAPI->getErrorMessage() << std::endl;
+                                std::cerr << gogAPI->getErrorMessage() << std::endl;
                                 gogAPI->clearError();
                                 continue;
                             }
@@ -790,7 +790,7 @@ void Downloader::repair()
                             std::string url = gogAPI->getInstallerLink(games[i].dlcs[j].gamename, games[i].dlcs[j].installers[k].id);
                             if (gogAPI->getError())
                             {
-                                std::cout << gogAPI->getErrorMessage() << std::endl;
+                                std::cerr << gogAPI->getErrorMessage() << std::endl;
                                 gogAPI->clearError();
                                 continue;
                             }
@@ -807,7 +807,7 @@ void Downloader::repair()
                         std::string filepath = games[i].dlcs[j].patches[k].getFilepath();
                         if (config.blacklist.isBlacklisted(filepath)) {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -818,7 +818,7 @@ void Downloader::repair()
                             XML = gogAPI->getXML(games[i].dlcs[j].gamename, games[i].dlcs[j].patches[k].id);
                             if (gogAPI->getError())
                             {
-                                std::cout << gogAPI->getErrorMessage() << std::endl;
+                                std::cerr << gogAPI->getErrorMessage() << std::endl;
                                 gogAPI->clearError();
                             }
                         }
@@ -826,7 +826,7 @@ void Downloader::repair()
                         std::string url = gogAPI->getPatchLink(games[i].dlcs[j].gamename, games[i].dlcs[j].patches[k].id);
                         if (gogAPI->getError())
                         {
-                            std::cout << gogAPI->getErrorMessage() << std::endl;
+                            std::cerr << gogAPI->getErrorMessage() << std::endl;
                             gogAPI->clearError();
                             continue;
                         }
@@ -842,14 +842,14 @@ void Downloader::repair()
                         std::string filepath = games[i].dlcs[j].extras[k].getFilepath();
                         if (config.blacklist.isBlacklisted(filepath)) {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
                         std::string url = gogAPI->getExtraLink(games[i].dlcs[j].gamename, games[i].dlcs[j].extras[k].id);
                         if (gogAPI->getError())
                         {
-                            std::cout << gogAPI->getErrorMessage() << std::endl;
+                            std::cerr << gogAPI->getErrorMessage() << std::endl;
                             gogAPI->clearError();
                             continue;
                         }
@@ -906,7 +906,7 @@ void Downloader::download()
                 if (config.blacklist.isBlacklisted(filepath))
                 {
                     if (config.bVerbose)
-                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                        std::cerr << "skipped blacklisted file " << filepath << std::endl;
                     continue;
                 }
 
@@ -914,7 +914,7 @@ void Downloader::download()
                 std::string url = gogAPI->getInstallerLink(games[i].gamename, games[i].installers[j].id);
                 if (gogAPI->getError())
                 {
-                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                     gogAPI->clearError();
                     continue;
                 }
@@ -928,7 +928,7 @@ void Downloader::download()
                         XML = gogAPI->getXML(games[i].gamename, games[i].installers[j].id);
                         if (gogAPI->getError())
                         {
-                            std::cout << gogAPI->getErrorMessage() << std::endl;
+                            std::cerr << gogAPI->getErrorMessage() << std::endl;
                             gogAPI->clearError();
                         }
                     }
@@ -949,7 +949,7 @@ void Downloader::download()
                 std::string url = gogAPI->getExtraLink(games[i].gamename, games[i].extras[j].id);
                 if (gogAPI->getError())
                 {
-                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                     gogAPI->clearError();
                     continue;
                 }
@@ -958,7 +958,7 @@ void Downloader::download()
                 if (config.blacklist.isBlacklisted(filepath))
                 {
                     if (config.bVerbose)
-                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                        std::cerr << "skipped blacklisted file " << filepath << std::endl;
                     continue;
                 }
 
@@ -993,7 +993,7 @@ void Downloader::download()
                 std::string url = gogAPI->getPatchLink(games[i].gamename, games[i].patches[j].id);
                 if (gogAPI->getError())
                 {
-                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                     gogAPI->clearError();
                     continue;
                 }
@@ -1002,7 +1002,7 @@ void Downloader::download()
                 if (config.blacklist.isBlacklisted(filepath))
                 {
                     if (config.bVerbose)
-                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                        std::cerr << "skipped blacklisted file " << filepath << std::endl;
                     continue;
                 }
 
@@ -1015,7 +1015,7 @@ void Downloader::download()
                         XML = gogAPI->getXML(games[i].gamename, games[i].patches[j].id);
                         if (gogAPI->getError())
                         {
-                            std::cout << gogAPI->getErrorMessage() << std::endl;
+                            std::cerr << gogAPI->getErrorMessage() << std::endl;
                             gogAPI->clearError();
                         }
                     }
@@ -1036,7 +1036,7 @@ void Downloader::download()
                 std::string url = gogAPI->getLanguagePackLink(games[i].gamename, games[i].languagepacks[j].id);
                 if (gogAPI->getError())
                 {
-                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                     gogAPI->clearError();
                     continue;
                 }
@@ -1045,7 +1045,7 @@ void Downloader::download()
                 if (config.blacklist.isBlacklisted(filepath))
                 {
                     if (config.bVerbose)
-                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                        std::cerr << "skipped blacklisted file " << filepath << std::endl;
                     continue;
                 }
 
@@ -1058,7 +1058,7 @@ void Downloader::download()
                         XML = gogAPI->getXML(games[i].gamename, games[i].languagepacks[j].id);
                         if (gogAPI->getError())
                         {
-                            std::cout << gogAPI->getErrorMessage() << std::endl;
+                            std::cerr << gogAPI->getErrorMessage() << std::endl;
                             gogAPI->clearError();
                         }
                     }
@@ -1088,7 +1088,7 @@ void Downloader::download()
                         if (config.blacklist.isBlacklisted(filepath))
                         {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -1096,7 +1096,7 @@ void Downloader::download()
                         std::string url = gogAPI->getInstallerLink(games[i].dlcs[j].gamename, games[i].dlcs[j].installers[k].id);
                         if (gogAPI->getError())
                         {
-                            std::cout << gogAPI->getErrorMessage() << std::endl;
+                            std::cerr << gogAPI->getErrorMessage() << std::endl;
                             gogAPI->clearError();
                             continue;
                         }
@@ -1110,7 +1110,7 @@ void Downloader::download()
                                 XML = gogAPI->getXML(games[i].dlcs[j].gamename, games[i].dlcs[j].installers[k].id);
                                 if (gogAPI->getError())
                                 {
-                                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                                     gogAPI->clearError();
                                 }
                             }
@@ -1130,7 +1130,7 @@ void Downloader::download()
                         if (config.blacklist.isBlacklisted(filepath))
                         {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -1138,7 +1138,7 @@ void Downloader::download()
                         std::string url = gogAPI->getPatchLink(games[i].dlcs[j].gamename, games[i].dlcs[j].patches[k].id);
                         if (gogAPI->getError())
                         {
-                            std::cout << gogAPI->getErrorMessage() << std::endl;
+                            std::cerr << gogAPI->getErrorMessage() << std::endl;
                             gogAPI->clearError();
                             continue;
                         }
@@ -1152,7 +1152,7 @@ void Downloader::download()
                                 XML = gogAPI->getXML(games[i].dlcs[j].gamename, games[i].dlcs[j].patches[k].id);
                                 if (gogAPI->getError())
                                 {
-                                    std::cout << gogAPI->getErrorMessage() << std::endl;
+                                    std::cerr << gogAPI->getErrorMessage() << std::endl;
                                     gogAPI->clearError();
                                 }
                             }
@@ -1172,7 +1172,7 @@ void Downloader::download()
                         if (config.blacklist.isBlacklisted(filepath))
                         {
                             if (config.bVerbose)
-                                std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                std::cerr << "skipped blacklisted file " << filepath << std::endl;
                             continue;
                         }
 
@@ -1180,7 +1180,7 @@ void Downloader::download()
                         std::string url = gogAPI->getExtraLink(games[i].dlcs[j].gamename, games[i].dlcs[j].extras[k].id);
                         if (gogAPI->getError())
                         {
-                            std::cout << gogAPI->getErrorMessage() << std::endl;
+                            std::cerr << gogAPI->getErrorMessage() << std::endl;
                             gogAPI->clearError();
                             continue;
                         }
@@ -1258,7 +1258,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
     {
         if (!boost::filesystem::is_directory(path))
         {
-            std::cout << path << " is not directory" << std::endl;
+            std::cerr << path << " is not directory" << std::endl;
             return res;
         }
     }
@@ -1266,7 +1266,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
     {
         if (!boost::filesystem::create_directories(path))
         {
-            std::cout << "Failed to create directory: " << path << std::endl;
+            std::cerr << "Failed to create directory: " << path << std::endl;
             return res;
         }
     }
@@ -1288,22 +1288,22 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
             }
             else
             {
-                std::cout << "Failed to reopen " << filepath << std::endl;
+                std::cerr << "Failed to reopen " << filepath << std::endl;
                 return res;
             }
         }
         else
         {   // File exists but is not the same version
             fclose(outfile);
-            std::cout << "Remote file is different, renaming local file" << std::endl;
+            std::cerr << "Remote file is different, renaming local file" << std::endl;
             std::string date_old = "." + bptime::to_iso_string(bptime::second_clock::local_time()) + ".old";
             boost::filesystem::path new_name = filepath + date_old; // Rename old file by appending date and ".old" to filename
             boost::system::error_code ec;
             boost::filesystem::rename(pathname, new_name, ec); // Rename the file
             if (ec)
             {
-                std::cout << "Failed to rename " << filepath << " to " << new_name.string() << std::endl;
-                std::cout << "Skipping file" << std::endl;
+                std::cerr << "Failed to rename " << filepath << " to " << new_name.string() << std::endl;
+                std::cerr << "Skipping file" << std::endl;
                 return res;
             }
             else
@@ -1316,7 +1316,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
                 }
                 else
                 {
-                    std::cout << "Failed to create " << filepath << std::endl;
+                    std::cerr << "Failed to create " << filepath << std::endl;
                     return res;
                 }
             }
@@ -1332,7 +1332,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
         }
         else
         {
-            std::cout << "Failed to create " << filepath << std::endl;
+            std::cerr << "Failed to create " << filepath << std::endl;
             return res;
         }
     }
@@ -1348,14 +1348,14 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
             {
                 if (!boost::filesystem::is_directory(path))
                 {
-                    std::cout << path << " is not directory" << std::endl;
+                    std::cerr << path << " is not directory" << std::endl;
                 }
             }
             else
             {
                 if (!boost::filesystem::create_directories(path))
                 {
-                    std::cout << "Failed to create directory: " << path << std::endl;
+                    std::cerr << "Failed to create directory: " << path << std::endl;
                 }
             }
             std::ofstream ofs(local_xml_file.string().c_str());
@@ -1366,7 +1366,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
             }
             else
             {
-                std::cout << "Can't create " << local_xml_file.string() << std::endl;
+                std::cerr << "Can't create " << local_xml_file.string() << std::endl;
             }
         }
     }
@@ -1383,7 +1383,7 @@ CURLcode Downloader::downloadFile(const std::string& url, const std::string& fil
         boost::filesystem::path path = filepath;
         if (boost::filesystem::exists(path))
             if (!boost::filesystem::remove(path))
-                std::cout << "Failed to delete " << path << std::endl;
+                std::cerr << "Failed to delete " << path << std::endl;
     }
 
     if (config.bReport)
@@ -2481,7 +2481,7 @@ void Downloader::checkOrphans()
     std::vector<std::string> orphans;
     for (unsigned int i = 0; i < games.size(); ++i)
     {
-        std::cout << "Checking for orphaned files " << i+1 << " / " << games.size() << "\r" << std::flush;
+        std::cerr << "Checking for orphaned files " << i+1 << " / " << games.size() << "\r" << std::flush;
         std::vector<boost::filesystem::path> filepath_vector;
 
         try
@@ -2531,7 +2531,7 @@ void Downloader::checkOrphans()
                                 std::string filepath = dir_iter->path().string();
                                 if (config.blacklist.isBlacklisted(filepath.substr(pathlen))) {
                                     if (config.bVerbose)
-                                        std::cout << "skipped blacklisted file " << filepath << std::endl;
+                                        std::cerr << "skipped ignorelisted file " << filepath << std::endl;
                                 } else {
                                     boost::regex expression(config.sOrphanRegex); // Limit to files matching the regex
                                     boost::match_results<std::string::const_iterator> what;
@@ -2544,7 +2544,7 @@ void Downloader::checkOrphans()
                     }
                 }
                 else
-                    std::cout << paths[j] << " does not exist" << std::endl;
+                    std::cerr << paths[j] << " does not exist" << std::endl;
             }
         }
         catch (const boost::filesystem::filesystem_error& ex)
@@ -3092,7 +3092,7 @@ std::vector<gameDetails> Downloader::getGameDetailsFromJsonNode(Json::Value root
         conf.vLanguagePriority = config.vLanguagePriority;
         conf.vPlatformPriority = config.vPlatformPriority;
         if (Util::getGameSpecificConfig(game.gamename, &conf) > 0)
-            std::cout << game.gamename << " - Language: " << conf.iInstallerLanguage << ", Platform: " << conf.iInstallerPlatform << ", DLC: " << (conf.bDLC ? "true" : "false") << std::endl;
+            std::cerr << game.gamename << " - Language: " << conf.iInstallerLanguage << ", Platform: " << conf.iInstallerPlatform << ", DLC: " << (conf.bDLC ? "true" : "false") << std::endl;
 
         for (unsigned int j = 0; j < nodes.size(); ++j)
         {

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -2668,6 +2668,8 @@ void Downloader::checkStatus()
             {
                 boost::filesystem::path filepath = games[i].installers[j].getFilepath();
 
+		if (config.blacklist.isBlacklisted(filepath.native()))
+		    continue;
                 std::string remoteHash;
                 std::string localHash;
                 bool bHashOK = true; // assume hash OK
@@ -2730,6 +2732,8 @@ void Downloader::checkStatus()
             {
                 boost::filesystem::path filepath = games[i].extras[j].getFilepath();
 
+		if (config.blacklist.isBlacklisted(filepath.native()))
+		    continue;
                 std::string localHash = this->getLocalFileHash(filepath.string(), games[i].gamename);
                 uintmax_t filesize;
 
@@ -2751,6 +2755,8 @@ void Downloader::checkStatus()
             {
                 boost::filesystem::path filepath = games[i].patches[j].getFilepath();
 
+		if (config.blacklist.isBlacklisted(filepath.native()))
+		    continue;
                 std::string localHash = this->getLocalFileHash(filepath.string(), games[i].gamename);
                 uintmax_t filesize;
 
@@ -2772,6 +2778,8 @@ void Downloader::checkStatus()
             {
                 boost::filesystem::path filepath = games[i].languagepacks[j].getFilepath();
 
+		if (config.blacklist.isBlacklisted(filepath.native()))
+		    continue;
                 std::string localHash = this->getLocalFileHash(filepath.string(), games[i].gamename);
                 uintmax_t filesize;
 
@@ -2797,6 +2805,8 @@ void Downloader::checkStatus()
                     {
                         boost::filesystem::path filepath = games[i].dlcs[j].installers[k].getFilepath();
 
+			if (config.blacklist.isBlacklisted(filepath.native()))
+			    continue;
                         std::string remoteHash;
                         std::string localHash;
                         bool bHashOK = true; // assume hash OK
@@ -2859,6 +2869,8 @@ void Downloader::checkStatus()
                     {
                         boost::filesystem::path filepath = games[i].dlcs[j].patches[k].getFilepath();
 
+			if (config.blacklist.isBlacklisted(filepath.native()))
+			    continue;
                         std::string localHash = this->getLocalFileHash(filepath.string(), games[i].dlcs[j].gamename);
                         uintmax_t filesize;
 
@@ -2880,6 +2892,8 @@ void Downloader::checkStatus()
                     {
                         boost::filesystem::path filepath = games[i].dlcs[j].extras[k].getFilepath();
 
+			if (config.blacklist.isBlacklisted(filepath.native()))
+			    continue;
                         std::string localHash = this->getLocalFileHash(filepath.string(), games[i].dlcs[j].gamename);
                         uintmax_t filesize;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -64,7 +64,7 @@ std::string Util::getFileHash(const std::string& filename, unsigned hash_id)
     rhash_library_init();
     int i = rhash_file(hash_id, filename.c_str(), digest);
     if (i < 0)
-        std::cout << "LibRHash error: " << strerror(errno) << std::endl;
+        std::cerr << "LibRHash error: " << strerror(errno) << std::endl;
     else
         rhash_print_bytes(result, digest, rhash_get_digest_size(hash_id), RHPR_HEX);
 
@@ -79,7 +79,7 @@ std::string Util::getChunkHash(unsigned char *chunk, uintmax_t chunk_size, unsig
     rhash_library_init();
     int i = rhash_msg(hash_id, chunk, chunk_size, digest);
     if (i < 0)
-        std::cout << "LibRHash error: " << strerror(errno) << std::endl;
+        std::cerr << "LibRHash error: " << strerror(errno) << std::endl;
     else
         rhash_print_bytes(result, digest, rhash_get_digest_size(hash_id), RHPR_HEX);
 
@@ -104,7 +104,7 @@ int Util::createXML(std::string filepath, uintmax_t chunk_size, std::string xml_
     boost::filesystem::path path = xml_dir;
     if (!boost::filesystem::exists(path)) {
         if (!boost::filesystem::create_directories(path)) {
-            std::cout << "Failed to create directory: " << path << std::endl;
+            std::cerr << "Failed to create directory: " << path << std::endl;
             return res;
         }
     }
@@ -115,7 +115,7 @@ int Util::createXML(std::string filepath, uintmax_t chunk_size, std::string xml_
         filesize = ftell(infile);
         rewind(infile);
     } else {
-        std::cout << filepath << " doesn't exist" << std::endl;
+        std::cerr << filepath << " doesn't exist" << std::endl;
         return res;
     }
 
@@ -159,13 +159,13 @@ int Util::createXML(std::string filepath, uintmax_t chunk_size, std::string xml_
         unsigned char *chunk = (unsigned char *) malloc(chunk_size * sizeof(unsigned char *));
         if (chunk == NULL)
         {
-            std::cout << "Memory error" << std::endl;
+            std::cerr << "Memory error" << std::endl;
             return res;
         }
         size = fread(chunk, 1, chunk_size, infile);
         if (size != chunk_size)
         {
-            std::cout << "Read error" << std::endl;
+            std::cerr << "Read error" << std::endl;
             free(chunk);
             return res;
         }
@@ -204,7 +204,7 @@ int Util::createXML(std::string filepath, uintmax_t chunk_size, std::string xml_
         fclose(xmlfile);
         res = 1;
     } else {
-        std::cout << "Can't create " << filenameXML << std::endl;
+        std::cerr << "Can't create " << filenameXML << std::endl;
         return res;
     }
 
@@ -311,8 +311,8 @@ int Util::getGameSpecificConfig(std::string gamename, gameSpecificConfig* conf, 
     }
     else
     {
-        std::cout << "Failed to parse game specific config " << filepath << std::endl;
-        std::cout << jsonparser->getFormattedErrorMessages() << std::endl;
+        std::cerr << "Failed to parse game specific config " << filepath << std::endl;
+        std::cerr << jsonparser->getFormattedErrorMessages() << std::endl;
     }
     delete jsonparser;
     if (json)
@@ -370,7 +370,7 @@ void Util::setFilePermissions(const boost::filesystem::path& path, const boost::
                 boost::filesystem::permissions(path, permissions, ec);
                 if (ec)
                 {
-                    std::cout << "Failed to set file permissions for " << path.string() << std::endl;
+                    std::cerr << "Failed to set file permissions for " << path.string() << std::endl;
                 }
             }
         }


### PR DESCRIPTION
Since a few revisions ago lgogdownloader finally worked for the first time for me, I played with it a bit and made some changes to make my life easier.  I would've sent these as individual issues with attached patches, but I'm too lazy and using github for that is a pain.  Sorry about that.  I expect you to just look at the diffs and take what you want, and reject this pull request as a whole.  The changes are described in the commit messages, but in summary:
  - won't build; can't find tinyxml on my system (not sure if this is right way to do it since I haven't used cmake in years, but it works for me)
  - tired of seeing gcc's excess semicolon warnings, so removed a few
  - I redirect output to a file, and don't want that file cluttered with stuff.  Also, password prompts won't appear when redirected.  To fix these, I put a bunch of messages on cerr.
  - The status checker is the most useful tool for me, and I'd like the blacklist to apply just as it does with other operations.
  - Orphan detection is screwy in a number of ways.  I didn't fix all my gripes with it, but I did fix a few.  In particular, issue #49 is properly fixed with this (using the same blackist file for opposite meanings is not).  My main gripe that still exists is that it should check the entire download root if no specific game is mentioned, so that renamed game dirs & the like are picked up.
  - Since lgogdownloader didn't work for so long, i am used to doing downloads manually.  Also, my network is flaky, and I don't trust programs to reliably download.  Since you only create the local XML files on download, there is no cached MD5 and --status takes for bloody ever.  As a temporary fix, I added automatic XML creation there as well.  A proper fix would be to also store the file modification date as well, and every time you check the XML file also ensure that the file hasn't changed (not present, not same size, or not same date).  If it does, delete the XML file and regenerate.

I also made some changes to fix how the sys/lang checks work, but they are incompatible with what you did recently and I haven't fixed them yet or provided a patch here.  I probably won't be submitting that as a patch in any case.  What I'd like to see is choosing the result only once, based on available binaries (and language packs, maybe, since I don't know how they work).  In particular, I don't want to see Windows patches when the Linux binary was chosen, but there were no Linux patches (as happens currently due to separate detection).  I sort of implemented this, but I'm not happy with how it works.  I'd also like to see patches filtered based on latest installed full binary (possible with a command-line option to enable this feature).  Out of my current 237-game library, only 1 requires a patch due to a non-existent latest binary.
