### PR TITLE
Add missing spaces in the apt install command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This repository contains the code of unofficial [GOG](http://www.gog.com/) downl
 ### Debian/Ubuntu
 
     # apt install build-essential libcurl4-openssl-dev libboost-regex-dev \
-    libjsoncpp-dev liboauth-dev librhash-dev libtinyxml2-dev libhtmlcxx-dev\
-    libboost-system-dev libboost-filesystem-dev libboost-program-options-dev\
+    libjsoncpp-dev liboauth-dev librhash-dev libtinyxml2-dev libhtmlcxx-dev \
+    libboost-system-dev libboost-filesystem-dev libboost-program-options-dev \
     libboost-date-time-dev help2man cmake libssl-dev
 
 ## Build and install


### PR DESCRIPTION
Without the spaces, the command-line produces an error (see http://unix.stackexchange.com/questions/289162 for an example).