### PR TITLE
Exit with non-zero status when some things fail

### DIFF
--- a/include/downloader.h
+++ b/include/downloader.h
@@ -72,7 +72,7 @@ class Downloader
         void checkOrphans();
         void checkStatus();
         void updateCache();
-        void downloadFileWithId(const std::string& fileid_string, const std::string& output_filepath);
+        int downloadFileWithId(const std::string& fileid_string, const std::string& output_filepath);
         void showWishlist();
         CURL* curlhandle;
         Timer timer;

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -65,7 +65,7 @@ class Downloader
         virtual ~Downloader();
         int init();
         int login();
-        void listGames();
+        int listGames();
         void updateCheck();
         void repair();
         void download();

--- a/main.cpp
+++ b/main.cpp
@@ -550,6 +550,9 @@ int main(int argc, char *argv[])
             return 1;
         }
     }
+
+    int res = 0;
+
     if (config.bShowWishlist)
         downloader.showWishlist();
     else if (config.bUpdateCache)
@@ -560,7 +563,7 @@ int main(int argc, char *argv[])
     {
         for (std::vector<std::string>::iterator it = vFileIdStrings.begin(); it != vFileIdStrings.end(); it++)
         {
-            downloader.downloadFileWithId(*it, config.sOutputFilename);
+            res |= downloader.downloadFileWithId(*it, config.sOutputFilename) ? 1 : 0;
         }
     }
     else if (config.bRepair) // Repair file
@@ -587,5 +590,5 @@ int main(int argc, char *argv[])
     if (!config.sOrphanRegex.empty() && config.bDownload)
         downloader.checkOrphans();
 
-    return 0;
+    return res;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -571,7 +571,7 @@ int main(int argc, char *argv[])
     else if (config.bDownload) // Download games
         downloader.download();
     else if (config.bListDetails || config.bList) // Detailed list of games/extras
-        downloader.listGames();
+        res = downloader.listGames();
     else if (!config.sOrphanRegex.empty()) // Check for orphaned files if regex for orphans is set
         downloader.checkOrphans();
     else if (config.bCheckStatus)

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -2790,8 +2790,9 @@ void Downloader::saveChangelog(const std::string& changelog, const std::string& 
     return;
 }
 
-void Downloader::downloadFileWithId(const std::string& fileid_string, const std::string& output_filepath)
+int Downloader::downloadFileWithId(const std::string& fileid_string, const std::string& output_filepath)
 {
+    int res = 1;
     size_t pos = fileid_string.find("/");
     if (pos == std::string::npos)
     {
@@ -2825,7 +2826,7 @@ void Downloader::downloadFileWithId(const std::string& fileid_string, const std:
             else
                 filepath = output_filepath;
             std::cout << "Downloading: " << filepath << std::endl;
-            this->downloadFile(url, filepath, std::string(), gamename);
+            res = this->downloadFile(url, filepath, std::string(), gamename);
             std::cout << std::endl;
         }
         else
@@ -2835,7 +2836,7 @@ void Downloader::downloadFileWithId(const std::string& fileid_string, const std:
         }
     }
 
-    return;
+    return res;
 }
 
 void Downloader::showWishlist()

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -495,12 +495,15 @@ int Downloader::getGameDetails()
     return 0;
 }
 
-void Downloader::listGames()
+int Downloader::listGames()
 {
     if (config.bListDetails) // Detailed list
     {
-        if (this->games.empty())
-            this->getGameDetails();
+        if (this->games.empty()) {
+            int res = this->getGameDetails();
+            if (res > 0)
+                return res;
+        }
 
         for (unsigned int i = 0; i < games.size(); ++i)
         {
@@ -696,6 +699,7 @@ void Downloader::listGames()
         }
     }
 
+    return 0;
 }
 
 void Downloader::repair()


### PR DESCRIPTION
Ideally all the downloader actions would exit with the right status but I only need it to work with `--download-file` right now. I also did `--list` and `--list-details` since they were easy enough.

I need this because I'd like to have lgogdownloader invoked automatically by Gentoo's package manager(s). I noticed that if a resumed download fails to start, the 0 exit status causes the package manager to treat it as a checksum failure and the partial file gets renamed.
