### PR TITLE
Add --respect-umask option to prevent adjusting permissions

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -48,6 +48,7 @@ class Config
         bool bShowWishlist;
         bool bAutomaticXMLCreation;
         bool bSaveChangelogs;
+        bool bRespectUmask;
         std::string sGameRegex;
         std::string sDirectory;
         std::string sCacheDirectory;

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -55,7 +55,8 @@ Downloader::~Downloader()
     curl_global_cleanup();
     ssl_thread_cleanup();
     // Make sure that cookie file is only readable/writable by owner
-    Util::setFilePermissions(config.sCookiePath, boost::filesystem::owner_read | boost::filesystem::owner_write);
+    if (!config.bRespectUmask)
+        Util::setFilePermissions(config.sCookiePath, boost::filesystem::owner_read | boost::filesystem::owner_write);
 }
 
 


### PR DESCRIPTION
I would like to use LGOGDownloader in conjunction with Gentoo's package manager, which may execute it as root, portage, or some other user in the portage group. A shared configuration under /etc will be used to avoid sandboxing issues. This will not be world readable.

All this permission stuff could be made simpler by adjusting the permissions of the parent directory instead of the files but it's up to you whether that approach should be taken instead.
