### PR TITLE
Made getTerminalWidth detect if it is running in a terminal

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -379,9 +379,16 @@ void Util::setFilePermissions(const boost::filesystem::path& path, const boost::
 
 int Util::getTerminalWidth()
 {
-    struct winsize w;
-    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
-    return static_cast<int>(w.ws_col);
+    int width;
+    if(isatty(STDOUT_FILENO))
+    {
+        struct winsize w;
+        ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+        width = static_cast<int>(w.ws_col);
+    }
+    else
+        width = 10000;//Something sufficiently big
+    return width;
 }
 
 


### PR DESCRIPTION
Before this change, if you tried to pipe the standard out to a file or run this as a process, it would fail.