### PR TITLE
Make libcurl usage thread-safe

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -34,6 +34,7 @@ API::API(const std::string& token, const std::string& secret)
     curl_easy_setopt(curlhandle, CURLOPT_NOPROGRESS, 1);
     curl_easy_setopt(curlhandle, CURLOPT_PROGRESSDATA, this);
     curl_easy_setopt(curlhandle, CURLOPT_FAILONERROR, true);
+    curl_easy_setopt(curlhandle, CURLOPT_NOSIGNAL, 1);
 
     this->error = false;
     this->config.oauth_token = token;

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -80,6 +80,7 @@ int Downloader::init()
     curl_easy_setopt(curlhandle, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(curlhandle, CURLOPT_USERAGENT, config.sVersionString.c_str());
     curl_easy_setopt(curlhandle, CURLOPT_NOPROGRESS, 0);
+    curl_easy_setopt(curlhandle, CURLOPT_NOSIGNAL, 1);
     curl_easy_setopt(curlhandle, CURLOPT_CONNECTTIMEOUT, config.iTimeout);
     curl_easy_setopt(curlhandle, CURLOPT_FAILONERROR, true);
     curl_easy_setopt(curlhandle, CURLOPT_SSL_VERIFYPEER, config.bVerifyPeer);
@@ -2805,6 +2806,7 @@ void Downloader::processDownloadQueue(Config conf, const unsigned int& tid)
     curl_easy_setopt(dlhandle, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(dlhandle, CURLOPT_USERAGENT, conf.sVersionString.c_str());
     curl_easy_setopt(dlhandle, CURLOPT_NOPROGRESS, 0);
+    curl_easy_setopt(dlhandle, CURLOPT_NOSIGNAL, 1);
 
     curl_easy_setopt(dlhandle, CURLOPT_CONNECTTIMEOUT, conf.iTimeout);
     curl_easy_setopt(dlhandle, CURLOPT_FAILONERROR, true);

--- a/src/website.cpp
+++ b/src/website.cpp
@@ -19,6 +19,7 @@ Website::Website(Config &conf)
     curl_easy_setopt(curlhandle, CURLOPT_FOLLOWLOCATION, 1);
     curl_easy_setopt(curlhandle, CURLOPT_USERAGENT, config.sVersionString.c_str());
     curl_easy_setopt(curlhandle, CURLOPT_NOPROGRESS, 1);
+    curl_easy_setopt(curlhandle, CURLOPT_NOSIGNAL, 1);
     curl_easy_setopt(curlhandle, CURLOPT_CONNECTTIMEOUT, config.iTimeout);
     curl_easy_setopt(curlhandle, CURLOPT_FAILONERROR, true);
     curl_easy_setopt(curlhandle, CURLOPT_COOKIEFILE, config.sCookiePath.c_str());


### PR DESCRIPTION
libcurl internally uses signals by default, which will crash the
application when using multiple threads.
Setting CURLOPT_NOSIGNAL on all handles avoids the crashes and is
recommended in the libcurl documentation.

See:
https://curl.haxx.se/libcurl/c/threadsafe.html
https://curl.haxx.se/libcurl/c/CURLOPT_NOSIGNAL.html