### PR TITLE
Add basic spec and instructions to build on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ This repository contains the code of unofficial [GOG](http://www.gog.com/) downl
     libboost-date-time-dev libboost-iostreams-dev help2man cmake libssl-dev \
     pkg-config zlib1g-dev
 
+### Building and installing on Fedora
+
+Update git commit in lgogdownloader.spec to the desired target.
+
+Update the version to today's date.
+
+    spectool -g lgogdownloader.spec
+    mock -r fedora-28-x86_64 --buildsrpm --sources=./ --spec=./lgogdownloader.spec
+    cp /var/lib/mock/fedora-28-x86_64/result/lgogdownloader-*.src.rpm ./
+    mock -r fedora-28-x86_64 lgogdownloader-*.src.rpm
+    cp /var/lib/mock/fedora-28-x86_64/result/lgogdownloader-*.x86_64.rpm ./
+    sudo dnf install ./lgogdownloader-*.x86_64.rpm
+
 ## Build and install
 
     $ mkdir build

--- a/lgogdownloader.spec
+++ b/lgogdownloader.spec
@@ -1,0 +1,52 @@
+%global gh_commit    3b733fcb4ba60c7e4407e76932796baac9eae911
+%global gh_short     %(c=%{gh_commit}; echo ${c:0:7})
+%global gh_owner     Sude-
+%global gh_project   lgogdownloader
+
+Name:	lgogdownloader
+Version:	20180531
+Release:	0.%{gh_short}%{?dist}
+Summary:	GOGDownloader for Linux
+
+License:	WTFPL
+URL:     https://github.com/%{gh_owner}/%{gh_project}
+Source0: https://github.com/%{gh_owner}/%{gh_project}/archive/%{gh_commit}/%{gh_project}-%{version}-%{gh_short}.tar.gz
+
+BuildRequires: cmake
+BuildRequires: boost-devel
+BuildRequires: libcurl-devel
+BuildRequires: openssl-devel
+BuildRequires: liboauth-devel
+BuildRequires: jsoncpp-devel
+BuildRequires: htmlcxx-devel
+BuildRequires: rhash-devel
+BuildRequires: tinyxml2-devel
+BuildRequires: zlib-devel
+BuildRequires: help2man
+BuildRequires: gzip
+
+%description
+LGOGDownloader is open source downloader to GOG.com for Linux users using the same API as the official GOGDownloader
+
+%prep
+%autosetup -n %{gh_project}-%{gh_commit}
+
+%build
+%cmake .
+%make_build
+
+
+%install
+%make_install
+
+
+%files
+%license COPYING
+%doc README.md
+%{_bindir}/lgogdownloader
+%{_mandir}/man1/lgogdownloader.1*
+
+
+
+%changelog
+


### PR DESCRIPTION
This adds a basic spec file and instructions on using it with mock to build an RPM on Fedora to use normal package management to install lgogdownloader