### PR TITLE
Fixed typo in  in ziputil.cpp

### DIFF
--- a/src/ziputil.cpp
+++ b/src/ziputil.cpp
@@ -6,7 +6,7 @@
 
 #include "ziputil.h"
 
-#include <sstream>
+#include <fstream>
 #include <sys/stat.h>
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>


### PR DESCRIPTION
Building the project fails because <fstream> isn't included in ziputil.cpp. I'm not a CPP developer, but after changing <sstream> to <fstream> the project built fine.