### PR TITLE
Fix find_path for newer jsoncpp release

### DIFF
--- a/cmake/FindJsoncpp.cmake
+++ b/cmake/FindJsoncpp.cmake
@@ -10,7 +10,7 @@ pkg_check_modules(PC_JSONCPP REQUIRED jsoncpp)
 
 find_path(JSONCPP_INCLUDE_DIR
   NAMES
-    json/features.h
+    json/allocator.h
   HINTS
     ${PC_JSONCPP_INCLUDEDIR}
     ${PC_JSONCPP_INCLUDEDIRS}


### PR DESCRIPTION
features.h was renamed but allocator.h wasn't so the latter works with both old and new versions.