### PR TITLE
Overwrite changelog only when modified

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -2331,15 +2331,15 @@ void Downloader::saveChangelog(const std::string& changelog, const std::string& 
         }
     }
 
-    // Check if changelog matches current changelog
+    // Check whether the changelog has changed
     if (boost::filesystem::exists(filepath))
     {
         std::ifstream ifs(filepath);
         if (ifs)
         {
-            std::string current_changelog((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+            std::string existing_changelog((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
             ifs.close();
-            if (changelog == current_changelog)
+            if (changelog == existing_changelog)
             {
                 std::cout << "Changelog unchanged. Skipping: " << filepath << std::endl;
                 return;

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -2331,6 +2331,22 @@ void Downloader::saveChangelog(const std::string& changelog, const std::string& 
         }
     }
 
+    // Check if changelog matches current changelog
+    if (boost::filesystem::exists(filepath))
+    {
+        std::ifstream ifs(filepath);
+        if (ifs)
+        {
+            std::string current_changelog((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+            ifs.close();
+            if (changelog == current_changelog)
+            {
+                std::cout << "Changelog unchanged. Skipping: " << filepath << std::endl;
+                return;
+            }
+        }
+    }
+
     std::ofstream ofs(filepath);
     if (ofs)
     {


### PR DESCRIPTION
On every run, each changelog file is overwritten even if the contents are the same. This modifies the mtime on the filesystem unnecessarily.

The changed `saveChangelog()` will not write to the changelog file in the case when the file already exists and the contents do not differ.  In all other cases, the changelog will be saved.