### PR TITLE
Fix getting redirect URL from curl

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -84,6 +84,7 @@ namespace Util
     std::string getStrippedString(std::string str);
     std::string makeEtaString(const unsigned long long& iBytesRemaining, const double& dlRate);
     std::string makeEtaString(const boost::posix_time::time_duration& duration);
+    std::string CurlHandleGetInfoString(CURL* curlhandle, CURLINFO info);
     void CurlHandleSetDefaultOptions(CURL* curlhandle, const CurlConfig& conf);
     CURLcode CurlGetResponse(const std::string& url, std::string& response, int max_retries = -1);
     CURLcode CurlHandleGetResponse(CURL* curlhandle, std::string& response, int max_retries = -1);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -756,6 +756,12 @@ void Util::CurlHandleSetDefaultOptions(CURL* curlhandle, const CurlConfig& conf)
         curl_easy_setopt(curlhandle, CURLOPT_CAINFO, conf.sCACertPath.c_str());
 }
 
+std::string Util::CurlHandleGetInfoString(CURL* curlhandle, CURLINFO info)
+{
+    char* str;
+    return (curl_easy_getinfo(curlhandle, info, &str) == CURLE_OK) ? str : "";
+}
+
 CURLcode Util::CurlGetResponse(const std::string& url, std::string& response, int max_retries)
 {
     CURLcode result;


### PR DESCRIPTION
The `char*` set by `curl_easy_getinfo` may not be valid after the next `curl_easy_perform`, so copy it to a `std::string` instead. Fixes #176.