### PR TITLE
Improve recaptcha detection

### DIFF
--- a/src/website.cpp
+++ b/src/website.cpp
@@ -270,7 +270,7 @@ int Website::Login(const std::string& email, const std::string& password)
         std::cerr << "DEBUG INFO (Website::Login)" << std::endl;
         std::cerr << login_form_html << std::endl;
     #endif
-    if (login_form_html.find("google.com/recaptcha") != std::string::npos)
+    if (login_form_html.find("class=\"g-recaptcha form__recaptcha\"") != std::string::npos)
     {
         bRecaptcha = true;
         #ifndef USE_QT_GUI_LOGIN


### PR DESCRIPTION
Recaptcha form is sometimes served from recaptcha.net (may be related to location). This detects the form based on class instead of domain, like [gogrepo](https://github.com/eddie3/gogrepo/blob/master/gogrepo.py#L553).