### PR TITLE
Retry download also on CURLE_SSL_CONNECT_ERROR

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -2804,6 +2804,7 @@ void Downloader::processDownloadQueue(Config conf, const unsigned int& tid)
                 case CURLE_PARTIAL_FILE:
                 case CURLE_OPERATION_TIMEDOUT:
                 case CURLE_RECV_ERROR:
+                case CURLE_SSL_CONNECT_ERROR:
                     bShouldRetry = true;
                     break;
                 // Retry on CURLE_HTTP_RETURNED_ERROR if response code is not "416 Range Not Satisfiable"


### PR DESCRIPTION
Sometimes the download fails with CURLE_SSL_CONNECT_ERROR and retrying is successful.
Sometimes multiple retries are needed, but that is already handled by the existing code.

I have been using this patch for at least a year.
It seems that GOG might have fixed whatever was causing the error, since I have not seen the retry trigger lately.