### PR TITLE
Cloud save support

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -103,6 +103,16 @@ class GalaxyConfig
             return this->token_json;
         }
 
+        std::string getUserId() {
+            std::unique_lock<std::mutex> lock(m);
+
+            if(this->token_json.isMember("user_id")) {
+                return this->token_json["user_id"].asString();
+            }
+
+            return {};
+        }
+
         void setJSON(Json::Value json)
         {
             std::unique_lock<std::mutex> lock(m);
@@ -135,13 +145,20 @@ class GalaxyConfig
         std::string getClientId()
         {
             std::unique_lock<std::mutex> lock(m);
-            return this->client_id;
+            if(token_json.isMember("client_id")) {
+                return token_json["client_id"].asString();
+            }
+
+            return default_client_id;
         }
 
         std::string getClientSecret()
         {
-            std::unique_lock<std::mutex> lock(m);
-            return this->client_secret;
+            if(token_json.isMember("client_secret")) {
+                return token_json["client_secret"].asString();
+            }
+
+            return default_client_secret;
         }
 
         std::string getRedirectUri()
@@ -155,8 +172,6 @@ class GalaxyConfig
         GalaxyConfig(const GalaxyConfig& other)
         {
             std::lock_guard<std::mutex> guard(other.m);
-            client_id = other.client_id;
-            client_secret = other.client_secret;
             redirect_uri = other.redirect_uri;
             filepath = other.filepath;
             token_json = other.token_json;
@@ -170,8 +185,6 @@ class GalaxyConfig
             std::unique_lock<std::mutex> lock1(m, std::defer_lock);
             std::unique_lock<std::mutex> lock2(other.m, std::defer_lock);
             std::lock(lock1, lock2);
-            client_id = other.client_id;
-            client_secret = other.client_secret;
             redirect_uri = other.redirect_uri;
             filepath = other.filepath;
             token_json = other.token_json;
@@ -179,8 +192,9 @@ class GalaxyConfig
         }
     protected:
     private:
-        std::string client_id = "46899977096215655";
-        std::string client_secret = "9d85c43b1482497dbbce61f6e4aa173a433796eeae2ca8c5f6129f2dc4de46d9";
+        const std::string default_client_id = "46899977096215655";
+        const std::string default_client_secret = "9d85c43b1482497dbbce61f6e4aa173a433796eeae2ca8c5f6129f2dc4de46d9";
+
         std::string redirect_uri = "https://embed.gog.com/on_login_success?origin=client";
         std::string filepath;
         Json::Value token_json;

--- a/include/config.h
+++ b/include/config.h
@@ -296,6 +296,10 @@ class Config
         Blacklist blacklist;
         Blacklist ignorelist;
         Blacklist gamehasdlc;
+
+        std::vector<std::string> cloudWhiteList;
+        std::vector<std::string> cloudBlackList;
+
         std::string sGameHasDLCList;
 
         // Integers

--- a/include/config.h
+++ b/include/config.h
@@ -19,6 +19,7 @@ struct DirectoryConfig
 {
     bool bSubDirectories;
     std::string sDirectory;
+    std::string sWinePrefix;
     std::string sGameSubdir;
     std::string sInstallersSubdir;
     std::string sExtrasSubdir;

--- a/include/config.h
+++ b/include/config.h
@@ -297,8 +297,10 @@ class Config
         Blacklist ignorelist;
         Blacklist gamehasdlc;
 
+        // Cloud save options
         std::vector<std::string> cloudWhiteList;
         std::vector<std::string> cloudBlackList;
+        bool bCloudForce;
 
         std::string sGameHasDLCList;
 

--- a/include/config.h
+++ b/include/config.h
@@ -142,9 +142,19 @@ class GalaxyConfig
             return this->filepath;
         }
 
+        void resetClient() {
+            std::lock_guard<std::mutex> lock(m);
+            if(token_json.isMember("client_id")) {
+                token_json["client_id"] = default_client_id;
+            }
+            if(token_json.isMember("client_secret")) {
+                token_json["client_secret"] = default_client_secret;
+            }
+        }
+
         std::string getClientId()
         {
-            std::unique_lock<std::mutex> lock(m);
+            std::lock_guard<std::mutex> lock(m);
             if(token_json.isMember("client_id")) {
                 return token_json["client_id"].asString();
             }
@@ -154,6 +164,7 @@ class GalaxyConfig
 
         std::string getClientSecret()
         {
+            std::lock_guard<std::mutex> lock(m);
             if(token_json.isMember("client_secret")) {
                 return token_json["client_secret"].asString();
             }

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -114,6 +114,7 @@ class Downloader
         void galaxyInstallGameById(const std::string& product_id, int build_index = -1, const unsigned int& iGalaxyArch = GlobalConstants::ARCH_X64);
         void galaxyShowBuilds(const std::string& product_id, int build_index = -1);
         void galaxyShowBuildsById(const std::string& product_id, int build_index = -1);
+        void galaxyShowCloudSavesById(const std::string& product_id, int build_index = -1);
     protected:
     private:
         CURLcode downloadFile(const std::string& url, const std::string& filepath, const std::string& xml_data = std::string(), const std::string& gamename = std::string());

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -101,10 +101,12 @@ class Downloader
         void clearUpdateNotifications();
         void repair();
         void download();
+        
         void downloadCloudSaves(const std::string& product_id, int build_index = -1);
         void downloadCloudSavesById(const std::string& product_id, int build_index = -1);
         void uploadCloudSaves(const std::string& product_id, int build_index = -1);
         void uploadCloudSavesById(const std::string& product_id, int build_index = -1);
+
         void checkOrphans();
         void checkStatus();
         void updateCache();

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -102,6 +102,9 @@ class Downloader
         void repair();
         void download();
         void downloadCloudSaves(const std::string& product_id, int build_index = -1);
+        void downloadCloudSavesById(const std::string& product_id, int build_index = -1);
+        void uploadCloudSaves(const std::string& product_id, int build_index = -1);
+        void uploadCloudSavesById(const std::string& product_id, int build_index = -1);
         void checkOrphans();
         void checkStatus();
         void updateCache();
@@ -144,6 +147,7 @@ class Downloader
         void saveChangelog(const std::string& changelog, const std::string& filepath);
         static void processDownloadQueue(Config conf, const unsigned int& tid);
         static void processCloudSaveDownloadQueue(Config conf, const unsigned int& tid);
+        static void processCloudSaveUploadQueue(Config conf, const unsigned int& tid);
         static int progressCallbackForThread(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
         template <typename T> void printProgress(const ThreadSafeQueue<T>& download_queue);
         static void getGameDetailsThread(Config config, const unsigned int& tid);

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -32,9 +32,11 @@
 #include <curl/curl.h>
 #include <json/json.h>
 #include <ctime>
+#include <functional>
 #include <fstream>
 #include <deque>
 
+class cloudSaveFile;
 class Timer
 {
     public:
@@ -99,6 +101,7 @@ class Downloader
         void clearUpdateNotifications();
         void repair();
         void download();
+        void downloadCloudSaves(const std::string& product_id, int build_index = -1);
         void checkOrphans();
         void checkStatus();
         void updateCache();
@@ -118,6 +121,8 @@ class Downloader
         void galaxyShowCloudSavesById(const std::string& product_id, int build_index = -1);
     protected:
     private:
+        int cloudSaveListByIdForEach(const std::string& product_id, int build_index, const std::function<void(cloudSaveFile &)> &f);
+
         CURLcode downloadFile(const std::string& url, const std::string& filepath, const std::string& xml_data = std::string(), const std::string& gamename = std::string());
         int repairFile(const std::string& url, const std::string& filepath, const std::string& xml_data = std::string(), const std::string& gamename = std::string());
         int getGameDetails();
@@ -135,6 +140,7 @@ class Downloader
         static std::string getChangelogFromJSON(const Json::Value& json);
         void saveChangelog(const std::string& changelog, const std::string& filepath);
         static void processDownloadQueue(Config conf, const unsigned int& tid);
+        static void processCloudSaveDownloadQueue(Config conf, const unsigned int& tid);
         static int progressCallbackForThread(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
         template <typename T> void printProgress(const ThreadSafeQueue<T>& download_queue);
         static void getGameDetailsThread(Config config, const unsigned int& tid);

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -106,6 +106,8 @@ class Downloader
         void downloadCloudSavesById(const std::string& product_id, int build_index = -1);
         void uploadCloudSaves(const std::string& product_id, int build_index = -1);
         void uploadCloudSavesById(const std::string& product_id, int build_index = -1);
+        void deleteCloudSaves(const std::string& product_id, int build_index = -1);
+        void deleteCloudSavesById(const std::string& product_id, int build_index = -1);
 
         void checkOrphans();
         void checkStatus();

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -117,10 +117,13 @@ class Downloader
         void galaxyInstallGameById(const std::string& product_id, int build_index = -1, const unsigned int& iGalaxyArch = GlobalConstants::ARCH_X64);
         void galaxyShowBuilds(const std::string& product_id, int build_index = -1);
         void galaxyShowCloudSaves(const std::string& product_id, int build_index = -1);
+        void galaxyShowLocalCloudSaves(const std::string& product_id, int build_index = -1);
+        void galaxyShowLocalCloudSavesById(const std::string& product_id, int build_index = -1);
         void galaxyShowBuildsById(const std::string& product_id, int build_index = -1);
         void galaxyShowCloudSavesById(const std::string& product_id, int build_index = -1);
     protected:
     private:
+        std::map<std::string, std::string> cloudSaveLocations(const std::string& product_id, int build_index);
         int cloudSaveListByIdForEach(const std::string& product_id, int build_index, const std::function<void(cloudSaveFile &)> &f);
 
         CURLcode downloadFile(const std::string& url, const std::string& filepath, const std::string& xml_data = std::string(), const std::string& gamename = std::string());

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -113,6 +113,7 @@ class Downloader
         void galaxyInstallGame(const std::string& product_id, int build_index = -1, const unsigned int& iGalaxyArch = GlobalConstants::ARCH_X64);
         void galaxyInstallGameById(const std::string& product_id, int build_index = -1, const unsigned int& iGalaxyArch = GlobalConstants::ARCH_X64);
         void galaxyShowBuilds(const std::string& product_id, int build_index = -1);
+        void galaxyShowCloudSaves(const std::string& product_id, int build_index = -1);
         void galaxyShowBuildsById(const std::string& product_id, int build_index = -1);
         void galaxyShowCloudSavesById(const std::string& product_id, int build_index = -1);
     protected:

--- a/include/galaxyapi.h
+++ b/include/galaxyapi.h
@@ -52,6 +52,7 @@ class galaxyAPI
         Json::Value getManifestV1(const std::string& product_id, const std::string& build_id, const std::string& manifest_id = "repository", const std::string& platform = "windows");
         Json::Value getManifestV1(const std::string& manifest_url);
         Json::Value getManifestV2(std::string manifest_hash, const bool& is_dependency = false);
+        Json::Value getCloudPathAsJson(const std::string &clientId);
         Json::Value getSecureLink(const std::string& product_id, const std::string& path);
         Json::Value getDependencyLink(const std::string& path);
         std::string getResponse(const std::string& url);

--- a/include/galaxyapi.h
+++ b/include/galaxyapi.h
@@ -46,8 +46,11 @@ class galaxyAPI
         galaxyAPI(CurlConfig& conf);
         virtual ~galaxyAPI();
         int init();
+
         bool isTokenExpired();
         bool refreshLogin();
+        bool refreshLogin(const std::string &clientId, const std::string &clientSecret, const std::string &refreshToken, bool newSession);
+
         Json::Value getProductBuilds(const std::string& product_id, const std::string& platform = "windows", const std::string& generation = "2");
         Json::Value getManifestV1(const std::string& product_id, const std::string& build_id, const std::string& manifest_id = "repository", const std::string& platform = "windows");
         Json::Value getManifestV1(const std::string& manifest_url);
@@ -55,8 +58,8 @@ class galaxyAPI
         Json::Value getCloudPathAsJson(const std::string &clientId);
         Json::Value getSecureLink(const std::string& product_id, const std::string& path);
         Json::Value getDependencyLink(const std::string& path);
-        std::string getResponse(const std::string& url);
-        Json::Value getResponseJson(const std::string& url);
+        std::string getResponse(const std::string& url, const char *encoding = nullptr);
+        Json::Value getResponseJson(const std::string& url, const char *encoding = nullptr);
         std::string hashToGalaxyPath(const std::string& hash);
         std::vector<galaxyDepotItem> getDepotItemsVector(const std::string& hash, const bool& is_dependency = false);
         Json::Value getProductInfo(const std::string& product_id);

--- a/include/util.h
+++ b/include/util.h
@@ -91,6 +91,7 @@ namespace Util
     CURLcode CurlHandleGetResponse(CURL* curlhandle, std::string& response, int max_retries = -1);
     curl_off_t CurlWriteMemoryCallback(char *ptr, curl_off_t size, curl_off_t nmemb, void *userp);
     curl_off_t CurlWriteChunkMemoryCallback(void *contents, curl_off_t size, curl_off_t nmemb, void *userp);
+    curl_off_t CurlReadChunkMemoryCallback(void *contents, curl_off_t size, curl_off_t nmemb, ChunkMemoryStruct *userp);
 
     template<typename ... Args> std::string formattedString(const std::string& format, Args ... args)
     {

--- a/include/util.h
+++ b/include/util.h
@@ -66,6 +66,7 @@ namespace Util
     int createXML(std::string filepath, uintmax_t chunk_size, std::string xml_dir = std::string());
     int getGameSpecificConfig(std::string gamename, gameSpecificConfig* conf, std::string directory = std::string());
     int replaceString(std::string& str, const std::string& to_replace, const std::string& replace_with);
+    int replaceAllString(std::string& str, const std::string& to_replace, const std::string& replace_with);
     void filepathReplaceReservedStrings(std::string& str, const std::string& gamename, const unsigned int& platformId = 0, const std::string& dlcname = "");
     void setFilePermissions(const boost::filesystem::path& path, const boost::filesystem::perms& permissions);
     int getTerminalWidth();

--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,18 @@ template<typename T> void set_vm_value(std::map<std::string, bpo::variable_value
     vm[option].value() = boost::any(value);
 }
 
+void ensure_trailing_slash(std::string &path, const char *default_ = nullptr) {
+    if (!path.empty())
+    {
+        if (path.at(path.length()-1)!='/')
+            path += "/";
+    }
+    else
+    {
+        path = default_; // Directory wasn't specified, use current directory
+    }
+}
+
 int main(int argc, char *argv[])
 {
     struct sigaction act;
@@ -223,6 +235,7 @@ int main(int argc, char *argv[])
         // Commandline options (config file)
         options_cli_cfg.add_options()
             ("directory", bpo::value<std::string>(&Globals::globalConfig.dirConf.sDirectory)->default_value("."), "Set download directory")
+            ("wine-prefix", bpo::value<std::string>(&Globals::globalConfig.dirConf.sWinePrefix)->default_value("."), "Set wineprefix directory")
             ("limit-rate", bpo::value<curl_off_t>(&Globals::globalConfig.curlConf.iDownloadRate)->default_value(0), "Limit download rate to value in kB\n0 = unlimited")
             ("xml-directory", bpo::value<std::string>(&Globals::globalConfig.sXMLDirectory), "Set directory for GOG XML files")
             ("chunk-size", bpo::value<size_t>(&Globals::globalConfig.iChunkSize)->default_value(10), "Chunk size (in MB) when creating XML")
@@ -580,15 +593,8 @@ int main(int argc, char *argv[])
     }
 
     // Make sure that directory has trailing slash
-    if (!Globals::globalConfig.dirConf.sDirectory.empty())
-    {
-        if (Globals::globalConfig.dirConf.sDirectory.at(Globals::globalConfig.dirConf.sDirectory.length()-1)!='/')
-            Globals::globalConfig.dirConf.sDirectory += "/";
-    }
-    else
-    {
-        Globals::globalConfig.dirConf.sDirectory = "./"; // Directory wasn't specified, use current directory
-    }
+    ensure_trailing_slash(Globals::globalConfig.dirConf.sDirectory, "./");
+    ensure_trailing_slash(Globals::globalConfig.dirConf.sWinePrefix, "./");
 
     // CA certificate bundle
     if (Globals::globalConfig.curlConf.sCACertPath.empty())
@@ -788,7 +794,7 @@ int main(int argc, char *argv[])
         {
             build_index = std::stoi(tokens[1]);
         }
-        downloader.galaxyShowCloudSavesById(product_id, build_index);
+        downloader.galaxyShowCloudSaves(product_id, build_index);
     }
     else if (!galaxy_product_id_install.empty())
     {

--- a/main.cpp
+++ b/main.cpp
@@ -151,6 +151,7 @@ int main(int argc, char *argv[])
 
     std::string galaxy_product_id_install;
     std::string galaxy_product_id_show_builds;
+    std::string galaxy_product_id_show_cloud_paths;
     std::string tags;
 
     std::vector<std::string> vFileIdStrings;
@@ -271,6 +272,7 @@ int main(int argc, char *argv[])
         options_cli_experimental.add_options()
             ("galaxy-install", bpo::value<std::string>(&galaxy_product_id_install)->default_value(""), "Install game using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-show-builds", bpo::value<std::string>(&galaxy_product_id_show_builds)->default_value(""), "Show game builds using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
+            ("galaxy-show-cloud-save-paths", bpo::value<std::string>(&galaxy_product_id_show_cloud_paths)->default_value(""), "Show game cloud-save paths using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-platform", bpo::value<std::string>(&sGalaxyPlatform)->default_value("w"), galaxy_platform_text.c_str())
             ("galaxy-language", bpo::value<std::string>(&sGalaxyLanguage)->default_value("en"), galaxy_language_text.c_str())
             ("galaxy-arch", bpo::value<std::string>(&sGalaxyArch)->default_value("x64"), galaxy_arch_text.c_str())
@@ -776,6 +778,17 @@ int main(int argc, char *argv[])
             build_index = std::stoi(tokens[1]);
         }
         downloader.galaxyShowBuilds(product_id, build_index);
+    }
+    else if (!galaxy_product_id_show_cloud_paths.empty())
+    {
+        int build_index = -1;
+        std::vector<std::string> tokens = Util::tokenize(galaxy_product_id_show_cloud_paths, "/");
+        std::string product_id = tokens[0];
+        if (tokens.size() == 2)
+        {
+            build_index = std::stoi(tokens[1]);
+        }
+        downloader.galaxyShowCloudSavesById(product_id, build_index);
     }
     else if (!galaxy_product_id_install.empty())
     {

--- a/main.cpp
+++ b/main.cpp
@@ -164,6 +164,7 @@ int main(int argc, char *argv[])
     std::string galaxy_product_id_install;
     std::string galaxy_product_id_show_builds;
     std::string galaxy_product_id_show_cloud_paths;
+    std::string galaxy_product_id_show_local_cloud_paths;
     std::string galaxy_product_cloud_saves;
     std::string tags;
 
@@ -288,6 +289,7 @@ int main(int argc, char *argv[])
             ("galaxy-show-builds", bpo::value<std::string>(&galaxy_product_id_show_builds)->default_value(""), "Show game builds using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-download-cloud-saves", bpo::value<std::string>(&galaxy_product_cloud_saves)->default_value(""), "Download cloud saves using product-id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-show-cloud-saves", bpo::value<std::string>(&galaxy_product_id_show_cloud_paths)->default_value(""), "Show game cloud-saves using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
+            ("galaxy-show-local-cloud-saves", bpo::value<std::string>(&galaxy_product_id_show_local_cloud_paths)->default_value(""), "Show local cloud-saves using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-platform", bpo::value<std::string>(&sGalaxyPlatform)->default_value("w"), galaxy_platform_text.c_str())
             ("galaxy-language", bpo::value<std::string>(&sGalaxyLanguage)->default_value("en"), galaxy_language_text.c_str())
             ("galaxy-arch", bpo::value<std::string>(&sGalaxyArch)->default_value("x64"), galaxy_arch_text.c_str())
@@ -797,6 +799,17 @@ int main(int argc, char *argv[])
             build_index = std::stoi(tokens[1]);
         }
         downloader.galaxyShowCloudSaves(product_id, build_index);
+    }
+    else if (!galaxy_product_id_show_local_cloud_paths.empty())
+    {
+        int build_index = -1;
+        std::vector<std::string> tokens = Util::tokenize(galaxy_product_id_show_local_cloud_paths, "/");
+        std::string product_id = tokens[0];
+        if (tokens.size() == 2)
+        {
+            build_index = std::stoi(tokens[1]);
+        }
+        downloader.galaxyShowLocalCloudSaves(product_id, build_index);
     }
     else if (!galaxy_product_id_install.empty())
     {

--- a/main.cpp
+++ b/main.cpp
@@ -166,6 +166,7 @@ int main(int argc, char *argv[])
     std::string galaxy_product_id_show_cloud_paths;
     std::string galaxy_product_id_show_local_cloud_paths;
     std::string galaxy_product_cloud_saves;
+    std::string galaxy_product_cloud_saves_delete;
     std::string galaxy_upload_product_cloud_saves;
     std::string tags;
 
@@ -296,6 +297,7 @@ int main(int argc, char *argv[])
             ("galaxy-upload-cloud-saves", bpo::value<std::string>(&galaxy_upload_product_cloud_saves)->default_value(""), "Upload cloud saves using product-id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-show-cloud-saves", bpo::value<std::string>(&galaxy_product_id_show_cloud_paths)->default_value(""), "Show game cloud-saves using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-show-local-cloud-saves", bpo::value<std::string>(&galaxy_product_id_show_local_cloud_paths)->default_value(""), "Show local cloud-saves using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
+            ("galaxy-delete-cloud-saves", bpo::value<std::string>(&galaxy_product_cloud_saves_delete)->default_value(""), "Delete cloud-saves using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-platform", bpo::value<std::string>(&sGalaxyPlatform)->default_value("w"), galaxy_platform_text.c_str())
             ("galaxy-language", bpo::value<std::string>(&sGalaxyLanguage)->default_value("en"), galaxy_language_text.c_str())
             ("galaxy-arch", bpo::value<std::string>(&sGalaxyArch)->default_value("x64"), galaxy_arch_text.c_str())
@@ -816,6 +818,17 @@ int main(int argc, char *argv[])
             build_index = std::stoi(tokens[1]);
         }
         downloader.galaxyShowLocalCloudSaves(product_id, build_index);
+    }
+    else if (!galaxy_product_cloud_saves_delete.empty())
+    {
+        int build_index = -1;
+        std::vector<std::string> tokens = Util::tokenize(galaxy_product_cloud_saves_delete, "/");
+        std::string product_id = tokens[0];
+        if (tokens.size() == 2)
+        {
+            build_index = std::stoi(tokens[1]);
+        }
+        downloader.deleteCloudSaves(product_id, build_index);
     }
     else if (!galaxy_product_id_install.empty())
     {

--- a/main.cpp
+++ b/main.cpp
@@ -233,6 +233,7 @@ int main(int argc, char *argv[])
             ("wine-prefix", bpo::value<std::string>(&Globals::globalConfig.dirConf.sWinePrefix)->default_value("."), "Set wineprefix directory")
             ("cloud-whitelist", bpo::value<std::vector<std::string>>(&Globals::globalConfig.cloudWhiteList)->multitoken(), "Include this list of cloud saves, by default all cloud saves are included\n Example: --cloud-whitelist saves/AutoSave-0 saves/AutoSave-1/screenshot.png")
             ("cloud-blacklist", bpo::value<std::vector<std::string>>(&Globals::globalConfig.cloudBlackList)->multitoken(), "Exclude this list of cloud saves\n Example: --cloud-blacklist saves/AutoSave-0 saves/AutoSave-1/screenshot.png")
+            ("cloud-force", bpo::value<bool>(&Globals::globalConfig.bCloudForce)->zero_tokens()->default_value(false), "Download or Upload cloud saves even if they're up-to-date\nDelete remote cloud saves even if no saves are whitelisted")
 #ifdef USE_QT_GUI_LOGIN
             ("enable-login-gui", bpo::value<bool>(&Globals::globalConfig.bEnableLoginGUI)->zero_tokens()->default_value(false), "Enable login GUI when encountering reCAPTCHA on login form")
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -166,6 +166,7 @@ int main(int argc, char *argv[])
     std::string galaxy_product_id_show_cloud_paths;
     std::string galaxy_product_id_show_local_cloud_paths;
     std::string galaxy_product_cloud_saves;
+    std::string galaxy_upload_product_cloud_saves;
     std::string tags;
 
     std::vector<std::string> vFileIdStrings;
@@ -288,6 +289,7 @@ int main(int argc, char *argv[])
             ("galaxy-install", bpo::value<std::string>(&galaxy_product_id_install)->default_value(""), "Install game using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-show-builds", bpo::value<std::string>(&galaxy_product_id_show_builds)->default_value(""), "Show game builds using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-download-cloud-saves", bpo::value<std::string>(&galaxy_product_cloud_saves)->default_value(""), "Download cloud saves using product-id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
+            ("galaxy-upload-cloud-saves", bpo::value<std::string>(&galaxy_upload_product_cloud_saves)->default_value(""), "Upload cloud saves using product-id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-show-cloud-saves", bpo::value<std::string>(&galaxy_product_id_show_cloud_paths)->default_value(""), "Show game cloud-saves using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-show-local-cloud-saves", bpo::value<std::string>(&galaxy_product_id_show_local_cloud_paths)->default_value(""), "Show local cloud-saves using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-platform", bpo::value<std::string>(&sGalaxyPlatform)->default_value("w"), galaxy_platform_text.c_str())
@@ -831,6 +833,16 @@ int main(int argc, char *argv[])
             build_index = std::stoi(tokens[1]);
         }
         downloader.downloadCloudSaves(product_id, build_index);
+    }
+    else if (!galaxy_upload_product_cloud_saves.empty()) {
+        int build_index = -1;
+        std::vector<std::string> tokens = Util::tokenize(galaxy_upload_product_cloud_saves, "/");
+        std::string product_id = tokens[0];
+        if (tokens.size() == 2)
+        {
+            build_index = std::stoi(tokens[1]);
+        }
+        downloader.uploadCloudSaves(product_id, build_index);
     }
     else
     {

--- a/main.cpp
+++ b/main.cpp
@@ -229,6 +229,10 @@ int main(int argc, char *argv[])
             ("cacert", bpo::value<std::string>(&Globals::globalConfig.curlConf.sCACertPath)->default_value(""), "Path to CA certificate bundle in PEM format")
             ("respect-umask", bpo::value<bool>(&Globals::globalConfig.bRespectUmask)->zero_tokens()->default_value(false), "Do not adjust permissions of sensitive files")
             ("user-agent", bpo::value<std::string>(&Globals::globalConfig.curlConf.sUserAgent)->default_value(DEFAULT_USER_AGENT), "Set user agent")
+
+            ("wine-prefix", bpo::value<std::string>(&Globals::globalConfig.dirConf.sWinePrefix)->default_value("."), "Set wineprefix directory")
+            ("cloud-whitelist", bpo::value<std::vector<std::string>>(&Globals::globalConfig.cloudWhiteList)->multitoken(), "Include this list of cloud saves, by default all cloud saves are included\n Example: --cloud-whitelist saves/AutoSave-0 saves/AutoSave-1/screenshot.png")
+            ("cloud-blacklist", bpo::value<std::vector<std::string>>(&Globals::globalConfig.cloudBlackList)->multitoken(), "Exclude this list of cloud saves\n Example: --cloud-blacklist saves/AutoSave-0 saves/AutoSave-1/screenshot.png")
 #ifdef USE_QT_GUI_LOGIN
             ("enable-login-gui", bpo::value<bool>(&Globals::globalConfig.bEnableLoginGUI)->zero_tokens()->default_value(false), "Enable login GUI when encountering reCAPTCHA on login form")
 #endif
@@ -238,7 +242,6 @@ int main(int argc, char *argv[])
         // Commandline options (config file)
         options_cli_cfg.add_options()
             ("directory", bpo::value<std::string>(&Globals::globalConfig.dirConf.sDirectory)->default_value("."), "Set download directory")
-            ("wine-prefix", bpo::value<std::string>(&Globals::globalConfig.dirConf.sWinePrefix)->default_value("."), "Set wineprefix directory")
             ("limit-rate", bpo::value<curl_off_t>(&Globals::globalConfig.curlConf.iDownloadRate)->default_value(0), "Limit download rate to value in kB\n0 = unlimited")
             ("xml-directory", bpo::value<std::string>(&Globals::globalConfig.sXMLDirectory), "Set directory for GOG XML files")
             ("chunk-size", bpo::value<size_t>(&Globals::globalConfig.iChunkSize)->default_value(10), "Chunk size (in MB) when creating XML")

--- a/main.cpp
+++ b/main.cpp
@@ -164,6 +164,7 @@ int main(int argc, char *argv[])
     std::string galaxy_product_id_install;
     std::string galaxy_product_id_show_builds;
     std::string galaxy_product_id_show_cloud_paths;
+    std::string galaxy_product_cloud_saves;
     std::string tags;
 
     std::vector<std::string> vFileIdStrings;
@@ -285,7 +286,8 @@ int main(int argc, char *argv[])
         options_cli_experimental.add_options()
             ("galaxy-install", bpo::value<std::string>(&galaxy_product_id_install)->default_value(""), "Install game using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-show-builds", bpo::value<std::string>(&galaxy_product_id_show_builds)->default_value(""), "Show game builds using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
-            ("galaxy-show-cloud-save-paths", bpo::value<std::string>(&galaxy_product_id_show_cloud_paths)->default_value(""), "Show game cloud-save paths using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
+            ("galaxy-download-cloud-saves", bpo::value<std::string>(&galaxy_product_cloud_saves)->default_value(""), "Download cloud saves using product-id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
+            ("galaxy-show-cloud-saves", bpo::value<std::string>(&galaxy_product_id_show_cloud_paths)->default_value(""), "Show game cloud-saves using product id [product_id/build_index] or gamename regex [gamename/build_id]\nBuild index is used to select a build and defaults to 0 if not specified.\n\nExample: 12345/2 selects build 2 for product 12345")
             ("galaxy-platform", bpo::value<std::string>(&sGalaxyPlatform)->default_value("w"), galaxy_platform_text.c_str())
             ("galaxy-language", bpo::value<std::string>(&sGalaxyLanguage)->default_value("en"), galaxy_language_text.c_str())
             ("galaxy-arch", bpo::value<std::string>(&sGalaxyArch)->default_value("x64"), galaxy_arch_text.c_str())
@@ -806,6 +808,16 @@ int main(int argc, char *argv[])
             build_index = std::stoi(tokens[1]);
         }
         downloader.galaxyInstallGame(product_id, build_index, Globals::globalConfig.dlConf.iGalaxyArch);
+    }
+    else if (!galaxy_product_cloud_saves.empty()) {
+        int build_index = -1;
+        std::vector<std::string> tokens = Util::tokenize(galaxy_product_cloud_saves, "/");
+        std::string product_id = tokens[0];
+        if (tokens.size() == 2)
+        {
+            build_index = std::stoi(tokens[1]);
+        }
+        downloader.downloadCloudSaves(product_id, build_index);
     }
     else
     {

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -4872,17 +4872,17 @@ void Downloader::galaxyShowCloudSavesById(const std::string& product_id, int bui
             auto time = boost::filesystem::last_write_time(filepath) - 1;
 
             if(csf.fileSize < size) {
-                std::cout << filepath << " :: not yet completed download" << std::endl;
+                std::cout << csf.path << " :: not yet completed download" << std::endl;
             }
             else if(boost::posix_time::from_time_t(time) <= csf.lastModified) {
-                std::cout << filepath << " :: Already up to date" << std::endl;
+                std::cout << csf.path << " :: Already up to date" << std::endl;
             }
             else {
-                std::cout << filepath << " :: Out of date"  << std::endl;
+                std::cout << csf.path << " :: Out of date"  << std::endl;
             }
         }
         else {
-            std::cout << filepath << " :: Isn't downloaded yet"  << std::endl;
+            std::cout << csf.path << " :: Isn't downloaded yet"  << std::endl;
         }
     });
 }

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -4798,7 +4798,7 @@ void Downloader::uploadCloudSavesById(const std::string& product_id, int build_i
         cloudSaveFile local_csf { std::move(it->second) };
         path_to_cloudSaveFile.erase(it);
 
-        if(csf.lastModified < local_csf.lastModified) {
+        if(Globals::globalConfig.bCloudForce || csf.lastModified < local_csf.lastModified) {
             iTotalRemainingBytes.fetch_add(local_csf.fileSize);
 
             dlCloudSaveQueue.push(local_csf);
@@ -4850,7 +4850,7 @@ void Downloader::downloadCloudSavesById(const std::string& product_id, int build
             // last_write_time minus a single second, since time_t is only accurate to the second unlike boost::posix_time::ptime
             auto time = boost::posix_time::from_time_t(boost::filesystem::last_write_time(filepath) - 1);
 
-            if(time <= csf.lastModified) {
+            if(!Globals::globalConfig.bCloudForce && time <= csf.lastModified) {
                 std::cout << "Already up to date -- skipping: " << csf.path << std::endl;
                 return; // This file is already completed
             }

--- a/src/galaxyapi.cpp
+++ b/src/galaxyapi.cpp
@@ -190,6 +190,12 @@ Json::Value galaxyAPI::getManifestV2(std::string manifest_hash, const bool& is_d
     return this->getResponseJson(url);
 }
 
+Json::Value galaxyAPI::getCloudPathAsJson(const std::string &clientId) {
+    std::string url = "https://remote-config.gog.com/components/galaxy_client/clients/" + clientId + "?component_version=2.0.51";
+
+    return this->getResponseJson(url);
+}
+
 Json::Value galaxyAPI::getSecureLink(const std::string& product_id, const std::string& path)
 {
     std::string url = "https://content-system.gog.com/products/" + product_id + "/secure_link?generation=2&path=" + path + "&_version=2";

--- a/src/galaxyapi.cpp
+++ b/src/galaxyapi.cpp
@@ -53,21 +53,31 @@ int galaxyAPI::init()
     return res;
 }
 
-bool galaxyAPI::refreshLogin()
+bool galaxyAPI::refreshLogin(const std::string &clientId, const std::string &clientSecret, const std::string &refreshToken, bool newSession)
 {
-    std::string refresh_url = "https://auth.gog.com/token?client_id=" + Globals::galaxyConf.getClientId()
-                            + "&client_secret=" + Globals::galaxyConf.getClientSecret()
+    std::string refresh_url = "https://auth.gog.com/token?client_id=" + clientId
+                            + "&client_secret=" + clientSecret
                             + "&grant_type=refresh_token"
-                            + "&refresh_token=" + Globals::galaxyConf.getRefreshToken();
+                            + "&refresh_token=" + refreshToken
+                            + (newSession ? "" : "&without_new_session=1");
 
+    // std::cout << refresh_url << std::endl;
     Json::Value token_json = this->getResponseJson(refresh_url);
 
     if (token_json.empty())
         return false;
 
+    token_json["client_id"] = clientId;
+    token_json["client_secret"] = clientSecret;
+
     Globals::galaxyConf.setJSON(token_json);
 
     return true;
+}
+
+bool galaxyAPI::refreshLogin()
+{
+    return refreshLogin(Globals::galaxyConf.getClientId(), Globals::galaxyConf.getClientSecret(), Globals::galaxyConf.getRefreshToken(), true);
 }
 
 bool galaxyAPI::isTokenExpired()
@@ -80,7 +90,7 @@ bool galaxyAPI::isTokenExpired()
     return res;
 }
 
-std::string galaxyAPI::getResponse(const std::string& url)
+std::string galaxyAPI::getResponse(const std::string& url, const char *encoding)
 {
     struct curl_slist *header = NULL;
 
@@ -92,13 +102,26 @@ std::string galaxyAPI::getResponse(const std::string& url)
         std::string bearer = "Authorization: Bearer " + access_token;
         header = curl_slist_append(header, bearer.c_str());
     }
+
+    if(encoding) {
+        auto accept = "Accept: " + std::string(encoding);
+        header = curl_slist_append(header, accept.c_str());
+    }
+
     curl_easy_setopt(curlhandle, CURLOPT_HTTPHEADER, header);
     curl_easy_setopt(curlhandle, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curlhandle, CURLOPT_ACCEPT_ENCODING, "");
 
     int max_retries = std::min(3, Globals::globalConfig.iRetries);
     std::string response;
-    Util::CurlHandleGetResponse(curlhandle, response, max_retries);
+    auto res = Util::CurlHandleGetResponse(curlhandle, response, max_retries);
+
+    if(res) {
+        long int response_code = 0;
+        curl_easy_getinfo(curlhandle, CURLINFO_RESPONSE_CODE, &response_code);
+
+        std::cout << "Response code for " << url << " is [" << response_code << ']' << std::endl;
+    }
 
     curl_easy_setopt(curlhandle, CURLOPT_ACCEPT_ENCODING, NULL);
     curl_easy_setopt(curlhandle, CURLOPT_HTTPHEADER, NULL);
@@ -107,9 +130,9 @@ std::string galaxyAPI::getResponse(const std::string& url)
     return response;
 }
 
-Json::Value galaxyAPI::getResponseJson(const std::string& url)
+Json::Value galaxyAPI::getResponseJson(const std::string& url, const char *encoding)
 {
-    std::istringstream response(this->getResponse(url));
+    std::istringstream response(this->getResponse(url, encoding));
     Json::Value json;
 
     if (!response.str().empty())
@@ -149,7 +172,12 @@ Json::Value galaxyAPI::getResponseJson(const std::string& url)
                 catch(const Json::Exception& exc)
                 {
                     // Failed to parse json
+
+                    std::cout << "Failed to parse json: " << exc.what();
                 }
+            }
+            else {
+                std::cout << "Failed to parse json: " << exc.what();
             }
         }
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -839,8 +839,9 @@ CURLcode Util::CurlHandleGetResponse(CURL* curlhandle, std::string& response, in
             // Retry on CURLE_HTTP_RETURNED_ERROR if response code is not "404 Not Found"
             case CURLE_HTTP_RETURNED_ERROR:
                 curl_easy_getinfo(curlhandle, CURLINFO_RESPONSE_CODE, &response_code);
-                if (response_code == 404)
+                if (response_code == 404 || response_code == 403) {
                     bShouldRetry = false;
+                }
                 else
                     bShouldRetry = true;
                 break;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -391,6 +391,22 @@ int Util::replaceString(std::string& str, const std::string& to_replace, const s
     return 1;
 }
 
+int Util::replaceAllString(std::string& str, const std::string& to_replace, const std::string& replace_with) {
+    size_t pos = str.find(to_replace);
+    if (pos == std::string::npos)
+    {
+        return 0;
+    }
+
+    do {
+        str.replace(str.begin()+pos, str.begin()+pos+to_replace.length(), replace_with);
+
+        pos = str.find(to_replace, pos + to_replace.length());
+    } while(pos != std::string::npos);
+    
+    return 1;
+}
+
 void Util::filepathReplaceReservedStrings(std::string& str, const std::string& gamename, const unsigned int& platformId, const std::string& dlcname)
 {
     std::string platform;

--- a/src/website.cpp
+++ b/src/website.cpp
@@ -264,6 +264,9 @@ std::vector<gameItem> Website::getGames()
 // Login to GOG website
 int Website::Login(const std::string& email, const std::string& password)
 {
+    // Reset client id and client secret to ensure we can log-in
+    Globals::galaxyConf.resetClient();
+
     int res = 0;
     std::string postdata;
     std::ostringstream memory;


### PR DESCRIPTION
With this PR I'm adding cloud save support for GOG. It allows you to download, upload and delete cloud saves.

**Command line options**
* --galaxy-show-cloud-saves product_id/build_index -> Show remote cloud saves
* --galaxy-show-local-cloud-saves product_id/build_index -> Show cloud saves locally stored
* --galaxy-download-cloud-saves product_id/build_index -> Download cloud saves
* --galaxy-upload-cloud-saves product_id/build_index -> Upload cloud saves
* --galaxy-delete-cloud-saves product_id/build_index -> Delete cloud saves
* --cloud-whitelist path1 path2 path3... -> Only include these files
* --cloud-blacklist path1 path2 path3... -> Exclude these files
* --cloud-force -> Depending on --galaxy command -> Force download/upload cloud saves even if they're up-to-date, Delete cloud saves even if no saves have been explicitly whitelisted


**Highlighted changes/additions to the code**
When downloading or uploading, the relevant files are put in a queue, which will be processed in `processCloudSaveDownloadQueue` and `processCloudSaveUploadQueue` respectively

For deletion, a simple DELETE request per file you wish to delete is sufficient.

The following variables have been added to the global config
```
        // Cloud save options
        std::vector<std::string> cloudWhiteList;
        std::vector<std::string> cloudBlackList;
        bool bCloudForce;
```

Let me know what you think of it :)