### PR TITLE
Correctly create empty files during Galaxy install

### DIFF
--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -4023,7 +4023,7 @@ void Downloader::processGalaxyDownloadQueue(const std::string& install_path, Con
             if (filesize == item.totalSizeUncompressed)
             {
                 // File is same size
-                if (Util::getFileHash(path.string(), RHASH_MD5) == item.md5)
+                if (item.totalSizeUncompressed == 0 || Util::getFileHash(path.string(), RHASH_MD5) == item.md5)
                 {
                     msgQueue.push(Message(path.string() + ": OK", MSGTYPE_SUCCESS, msg_prefix, MSGLEVEL_DEFAULT));
                     continue;
@@ -4125,6 +4125,14 @@ void Downloader::processGalaxyDownloadQueue(const std::string& install_path, Con
 
         bool bChunkFailure = false;
         std::time_t timestamp = -1;
+        // Handle empty files
+        if (item.chunks.empty())
+        {
+            // Create empty file
+            std::ofstream ofs(path.string(), std::ofstream::out | std::ofstream::binary);
+            if (ofs)
+                ofs.close();
+        }
         for (unsigned int j = start_chunk; j < item.chunks.size(); ++j)
         {
             // Refresh Galaxy login if token is expired

--- a/src/galaxyapi.cpp
+++ b/src/galaxyapi.cpp
@@ -258,7 +258,7 @@ std::vector<galaxyDepotItem> galaxyAPI::getDepotItemsVector(const std::string& h
 
     for (unsigned int i = 0; i < json["depot"]["items"].size(); ++i)
     {
-        if (!json["depot"]["items"][i]["chunks"].empty())
+        if (json["depot"]["items"][i]["chunks"].isArray())
         {
             galaxyDepotItem item;
             item.totalSizeCompressed = 0;
@@ -287,6 +287,8 @@ std::vector<galaxyDepotItem> galaxyAPI::getDepotItemsVector(const std::string& h
                 item.md5 = json["depot"]["items"][i]["md5"].asString();
             else if (json["depot"]["items"][i]["chunks"].size() == 1)
                 item.md5 = json["depot"]["items"][i]["chunks"][0]["md5"].asString();
+            else
+                item.md5 = std::string();
 
             items.push_back(item);
         }


### PR DESCRIPTION
I noticed that empty files were missing when using the Galaxy install option. These files were required by the game I downloaded.

I looked into it and realized the code simply skips all files with no chunks. I did some minimal changes to ensure files with no chunks are added to the file list and handled correctly during downloading.

I verified that the empty files are now correctly created and not deleted when using `--galaxy-delete-orphans`.

Let me know if you have any concerns with this.