### PR TITLE
CMake: Fix build with Boost 1.89.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,13 @@ endif(USE_QT_GUI)
 find_package(Boost
   CONFIG
   REQUIRED
-  system
   filesystem
   regex
   program_options
   date_time
   iostreams
+  OPTIONAL_COMPONENTS
+  system
   )
 find_package(CURL 7.55.0 REQUIRED)
 find_package(Jsoncpp REQUIRED)


### PR DESCRIPTION
In the upcoming Boost 1.89.0 release, Boost.System stub has been removed (https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3) which causes a CMake error.

I noticed this while testing 1.89.0.beta1 in Homebrew https://github.com/Homebrew/homebrew-core/pull/233031.

I wasn't sure if there was a minimum Boost version for this project. With Boost 1.69[^1] or later, you can just remove `system`. However, for older versions, upstream has recommended OPTIONAL_COMPONENTS, see: `https://github.com/boostorg/system/issues/132#issuecomment-3146378680`

[^1]: https://www.boost.org/doc/libs/1_69_0/libs/system/doc/html/system.html#changes_in_boost_1_69