### PR TITLE
Util: Gracefully fail when $HOME is unset

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -459,7 +459,14 @@ std::vector<std::string> Util::getDLCNamesFromJSON(const Json::Value &root)
 
 std::string Util::getHomeDir()
 {
-    return (std::string)getenv("HOME");
+    const char* home = getenv("HOME");
+
+    if (!home) {
+        std::cerr << "$HOME is missing, unable to continue.\n";
+        exit(1);
+    } else {
+        return std::string(home);
+    }
 }
 
 std::string Util::getConfigHome()


### PR DESCRIPTION
Add an error message to inform the user of a missing $HOME variable. Currently this causes the program to segfault:

```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
Aborted                    (core dumped) ./build/lgogdownloader
```

To replicate unset $HOME before running a build of the current master branch (2c55e27f829933869c39ee6255d30a91d2ffebfa).

Now the program will fail with:

```
$HOME is missing, unable to continue.
```