### PR TITLE
BUGFIX: std::out_of_range on very small terminal widths.

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -609,16 +609,12 @@ std::string Util::getLocalFileHash(const std::string& xml_dir, const std::string
 
 void Util::shortenStringToTerminalWidth(std::string& str)
 {
-    int iStrLen = static_cast<int>(str.length());
-    int iTermWidth = Util::getTerminalWidth();
-    if (iStrLen >= iTermWidth)
-    {
-        size_t chars_to_remove = (iStrLen - iTermWidth) + 4;
-        size_t middle = iStrLen / 2;
-        size_t pos1 = middle - (chars_to_remove / 2);
-        size_t pos2 = middle + (chars_to_remove / 2);
-        str.replace(str.begin()+pos1, str.begin()+pos2, "...");
-    }
+    const size_t iTermWidth = Util::getTerminalWidth();
+    if (str.size() <= iTermWidth || iTermWidth < 4)
+        return;
+
+    const size_t iCharsToKeep = (iTermWidth - 3) / 2;
+    str = str.substr(0, iCharsToKeep) + "..." + str.substr(str.size() - iCharsToKeep);
 }
 
 std::string Util::getJsonUIntValueAsString(const Json::Value& json_value)


### PR DESCRIPTION
Hello!

I was trying to use this tool to download games inside a nix derivation for my gog account.

Inside the sandbox, I hit a bug where the shortening of the string to the terminal width would result in a crash, since a terminal width <=2 would lead to a negative number (unsigned = very big number).

Godbolt example: https://mmm.godbolt.org/z/hqddzhnsY

To fix this I rewrote the function to take into account the width of the terminal, if it's too small, I decide to just do nothing instead of clearing the string, since it's then obvious that the width is misreported.


I confirmed that after changing this function, I'm able to download inside the sandbox.