### PR TITLE
Add --check-obsolete and --delete-obsolete

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,10 +42,13 @@ jobs:
           CXX: ${{matrix.cxx_compiler}}
         run: |
           cmake -Bbuild -DCMAKE_BUILD_TYPE=Release \
-                -DUSE_QT_GUI=${{matrix.qt_gui}} -GNinja
+                -DUSE_QT_GUI=${{matrix.qt_gui}} -DBUILD_TESTS=YES -GNinja
 
       - name: Build
         run: ninja -Cbuild
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
 
       - name: Run
         run: cd build && ./lgogdownloader --help

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRC_FILES
   src/gamedetails.cpp
   src/galaxyapi.cpp
   src/ziputil.cpp
+  src/obsolete.cpp
   src/catalogmetadata.cpp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,3 +188,79 @@ set(INSTALL_SHARE_DIR share CACHE PATH "Installation directory for resource file
 
 install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX}" DESTINATION ${INSTALL_BIN_DIR})
 add_subdirectory(man)
+
+option(BUILD_TESTS "Build unit tests" OFF)
+if(BUILD_TESTS)
+  enable_testing()
+
+  # The tests compile project sources directly, so they need the same dependency
+  # include directories and libraries the main target gets.
+  add_library(lgogdownloader_test_deps INTERFACE)
+  target_include_directories(lgogdownloader_test_deps INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+  target_link_libraries(lgogdownloader_test_deps INTERFACE
+    Boost::boost
+    Boost::date_time
+    Boost::filesystem
+    Boost::iostreams
+    Boost::program_options
+    Boost::regex
+    CURL::libcurl
+    Threads::Threads
+    ZLIB::ZLIB
+  )
+
+  if(TARGET JsonCpp::JsonCpp)
+    target_link_libraries(lgogdownloader_test_deps INTERFACE JsonCpp::JsonCpp)
+  else()
+    target_include_directories(lgogdownloader_test_deps INTERFACE ${Jsoncpp_INCLUDE_DIRS})
+    target_link_libraries(lgogdownloader_test_deps INTERFACE ${Jsoncpp_LIBRARIES})
+  endif()
+
+  if(TARGET tinyxml2::tinyxml2)
+    target_link_libraries(lgogdownloader_test_deps INTERFACE tinyxml2::tinyxml2)
+  else()
+    target_include_directories(lgogdownloader_test_deps INTERFACE ${Tinyxml2_INCLUDE_DIRS})
+    target_link_libraries(lgogdownloader_test_deps INTERFACE ${Tinyxml2_LIBRARIES})
+  endif()
+
+  if(TARGET LibRHash::LibRHash)
+    target_link_libraries(lgogdownloader_test_deps INTERFACE LibRHash::LibRHash)
+  else()
+    target_include_directories(lgogdownloader_test_deps INTERFACE ${Rhash_INCLUDE_DIRS})
+    target_link_libraries(lgogdownloader_test_deps INTERFACE ${Rhash_LIBRARIES})
+  endif()
+
+  if(TARGET tidy-html5::tidy-html5)
+    target_link_libraries(lgogdownloader_test_deps INTERFACE tidy-html5::tidy-html5)
+  else()
+    target_include_directories(lgogdownloader_test_deps INTERFACE ${Tidy_INCLUDE_DIRS})
+    target_link_libraries(lgogdownloader_test_deps INTERFACE ${Tidy_LIBRARIES})
+  endif()
+
+  add_executable(obsolete_tests
+    tests/obsolete_tests.cpp
+    src/obsolete.cpp
+  )
+
+  add_executable(gamedetails_filter_tests
+    tests/gamedetails_filter_tests.cpp
+    src/gamedetails.cpp
+    src/gamefile.cpp
+    src/util.cpp
+    src/blacklist.cpp
+  )
+
+  add_executable(catalog_metadata_tests
+    tests/catalog_metadata_tests.cpp
+    src/catalogmetadata.cpp
+  )
+
+  foreach(test_target obsolete_tests gamedetails_filter_tests catalog_metadata_tests)
+    set_property(TARGET ${test_target} PROPERTY CXX_STANDARD 17)
+    # These targets contain no Q_OBJECT and link no Qt, but they would otherwise
+    # inherit the directory scoped AUTOMOC/AUTOUIC set for the Qt GUI build.
+    set_target_properties(${test_target} PROPERTIES AUTOMOC OFF AUTOUIC OFF)
+    target_link_libraries(${test_target} PRIVATE lgogdownloader_test_deps)
+    add_test(NAME ${test_target} COMMAND ${test_target})
+  endforeach()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRC_FILES
   src/gamedetails.cpp
   src/galaxyapi.cpp
   src/ziputil.cpp
+  src/catalogmetadata.cpp
 )
 
 if(USE_QT_GUI)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,62 @@ make
         lgogdownloader --repair --game beneath_a_steel_sky
         lgogdownloader --repair --download --game "^a"
 
+- **Removing superseded installers after an update**
+
+        # Report local files that GOG's current catalog no longer offers
+        lgogdownloader --check-obsolete
+
+        # Download the selected current files, verify them, then delete superseded files
+        lgogdownloader --download --check-obsolete --delete-obsolete \
+            --platform windows+linux --language en+de
+
+  A file is obsolete only when GOG's *current catalog no longer offers it*. The
+  protected set is always the whole catalog: every platform, every language and
+  every file type, regardless of what `--platform`, `--language`, `--include` or
+  `--exclude` selected for this run. Those options still control what gets
+  downloaded and verified, but a file GOG still offers is never deleted just
+  because this run was not asked to download it. Resolving the full catalog is
+  what makes the check safe, and also what makes it slow: even a no-download
+  obsolete scan can take several minutes on a large library.
+  It compares exact paths from GOG metadata, so split `.exe`/`.bin` installers,
+  DLCs and legitimate architecture or edition alternatives do not rely on
+  filename version parsing.
+
+  `--delete-obsolete` deletes from a game directory only after every selected
+  current file in that directory exists and matches its exact current download
+  size and, for installers, patches and language packs, its freshly computed
+  checksum; extras are verified by size alone. Deletion from a game directory is
+  refused if size or checksum metadata cannot be retrieved, if the current
+  catalog listed no file at all for that directory, if the run has no selected
+  current file there to verify against, or if that game's catalog metadata came
+  back incomplete. An incomplete response is never treated as evidence that a
+  local file is obsolete: the affected game is reported but never pruned, while
+  the rest of the library is still checked.
+  Verification is performed only for directories that actually have obsolete
+  candidates. Blacklisted and ignorelisted files are never reported or deleted.
+  `--check-obsolete` always uses the live catalog and never the `--use-cache`
+  copy.
+
+  Like `--check-orphans`, the scan treats every file under a game directory as
+  something lgogdownloader manages. If you point `--subdir-galaxy-install` at the
+  same directory as `--subdir-game`, a Galaxy-installed game tree will be seen as
+  obsolete; keep the two apart.
+
+  Two things the current catalog cannot describe, so a local copy of them is
+  reported as obsolete: files GOG lists for information only (`count` and
+  `total_size` of zero, skipped since #200), and files belonging to a DLC the
+  account no longer owns. Neither has a resolvable download path, so there is
+  nothing to compare a local file against. Blacklist them if you keep such files.
+
+  A game is skipped when `%version%` appears in one of its directory templates.
+  The game root has no version of its own, so it would span every version
+  directory while the catalog paths inside it are version specific, and anything
+  left at a previous version's path would look obsolete.
+
+  `--check-obsolete` exits non-zero if any game was skipped or any game directory
+  was refused, so `exit 0` means the whole selection was checked. With
+  `--delete-obsolete` it also exits non-zero if a deletion failed.
+
 - **Using Galaxy API for listing and installing game builds**
 
         lgogdownloader --galaxy-platform windows --galaxy-show-builds stardew_valley

--- a/include/catalogmetadata.h
+++ b/include/catalogmetadata.h
@@ -1,0 +1,41 @@
+/* This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details. */
+
+#ifndef CATALOGMETADATA_H
+#define CATALOGMETADATA_H
+
+#include <string>
+
+#include <json/json.h>
+
+namespace CatalogMetadata
+{
+    enum class ResolutionFailure
+    {
+        None,
+        EmptyResponse,
+        MalformedResponse,
+        MissingDownlink,
+        EmptyPath,
+        InvalidPath
+    };
+
+    ResolutionFailure validateFileResolution(
+        const Json::Value& downlinkJson,
+        const std::string& resolvedPath
+    );
+    unsigned int countMissingDownloadSections(
+        const Json::Value& productJson,
+        const unsigned int& includeTypes
+    );
+    bool hasCompleteDlcExpansion(const Json::Value& productJson);
+    bool hasCompleteDownloadGroup(const Json::Value& group, bool requirePlatformLanguage);
+    bool isEmptyDownloadGroup(const Json::Value& group);
+    bool hasCompleteFileEntry(const Json::Value& file);
+    std::string scalarString(const Json::Value& value);
+}
+
+#endif // CATALOGMETADATA_H

--- a/include/config.h
+++ b/include/config.h
@@ -57,6 +57,7 @@ struct DownloadConfig
     bool bDuplicateHandler;
     bool bGalaxyDependencies;
     bool bDeleteOrphans;
+    bool bDeleteObsolete;
     bool bGalaxyLowercasePath;
 };
 
@@ -295,6 +296,7 @@ class Config
         // Regex
         std::string sGameRegex;
         std::string sOrphanRegex;
+        std::string sObsoleteRegex;
         std::string sIgnoreDLCCountRegex;
 
         // Priorities

--- a/include/downloader.h
+++ b/include/downloader.h
@@ -112,6 +112,7 @@ class Downloader
         void deleteCloudSavesById(const std::string& product_id, const std::string& build_id = std::string());
 
         void checkOrphans();
+        int checkObsolete();
         void checkStatus();
         void updateCache();
         int downloadFileWithId(const std::string& fileid_string, const std::string& output_filepath);
@@ -146,6 +147,7 @@ class Downloader
         std::string getResponse(const std::string& url);
         std::string getLocalFileHash(const std::string& filepath, const std::string& gamename = std::string());
         std::string getRemoteFileHash(const gameFile& gf);
+        bool getRemoteFileVerification(const gameFile& gf, uintmax_t& remoteSize, std::string& remoteHash, const bool& bNeedSize = true);
         void addStatusLine(const std::string& statusCode, const std::string& gamename, const std::string& filepath, const uintmax_t& filesize, const std::string& localHash);
         int loadGameDetailsCache();
         int saveGameDetailsCache();
@@ -184,6 +186,7 @@ class Downloader
         galaxyAPI *gogGalaxy;
         std::vector<gameItem> gameItems;
         std::vector<gameDetails> games;
+        std::vector<gameDetails> currentCatalogGames;
 
         off_t resume_position;
         int retries;

--- a/include/galaxyapi.h
+++ b/include/galaxyapi.h
@@ -78,7 +78,7 @@ class galaxyAPI
         CurlConfig curlConf;
         static size_t writeMemoryCallback(char *ptr, size_t size, size_t nmemb, void *userp);
         CURL* curlhandle;
-        std::vector<gameFile> fileJsonNodeToGameFileVector(const std::string& gamename, const Json::Value& json, const unsigned int& type, const DownloadConfig& dlConf);
+        std::vector<gameFile> fileJsonNodeToGameFileVector(const std::string& gamename, const Json::Value& json, const unsigned int& type, const DownloadConfig& dlConf, unsigned int& metadataFailures);
 };
 
 #endif // GALAXYAPI_H

--- a/include/gamedetails.h
+++ b/include/gamedetails.h
@@ -37,6 +37,10 @@ class gameDetails
         std::string logo;
         std::string gameDetailsJson;
         std::string productJson;
+        unsigned int metadataFailures = 0;
+        void filterWithPlatformLanguage(const DownloadConfig& config);
+        void filterDuplicates();
+        void filterDlcsWithInclude(const unsigned int& iInclude);
         void filterWithPriorities(const gameSpecificConfig& config);
         void makeFilepaths(const DirectoryConfig& config);
         std::string getSerialsFilepath();
@@ -49,9 +53,11 @@ class gameDetails
         std::vector<gameFile> getGameFileVector();
         std::vector<gameFile> getGameFileVectorFiltered(const unsigned int& iType);
         void filterWithType(const unsigned int& iType);
-        std::string makeCustomFilepath(const std::string& filename, const gameDetails& gd, const DirectoryConfig& dirConf);
+        std::string makeCustomFilepath(const std::string& filename, const gameDetails& gd, const DirectoryConfig& dirConf, const unsigned int& platform = GlobalConstants::PLATFORM_WINDOWS);
         virtual ~gameDetails();
     protected:
+        void filterListWithPlatformLanguage(std::vector<gameFile>& list, const DownloadConfig& config);
+        void filterDuplicateList(std::vector<gameFile>& list);
         void filterListWithPriorities(std::vector<gameFile>& list, const gameSpecificConfig& config);
         void filterListWithType(std::vector<gameFile>& list, const unsigned int& iType);
         std::string makeFilepath(const gameFile& gf, const DirectoryConfig& dirConf);

--- a/include/obsolete.h
+++ b/include/obsolete.h
@@ -1,0 +1,33 @@
+/* This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details. */
+
+#ifndef OBSOLETE_H
+#define OBSOLETE_H
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include <boost/filesystem/path.hpp>
+#include <boost/regex.hpp>
+
+namespace Obsolete
+{
+    std::string pathKey(const boost::filesystem::path& path);
+    bool isWithin(const boost::filesystem::path& root, const boost::filesystem::path& path);
+    std::string relativeKey(const boost::filesystem::path& root, const boost::filesystem::path& path);
+    std::vector<boost::filesystem::path> collectCandidates(
+        const boost::filesystem::path& root,
+        const boost::regex& expression
+    );
+    std::vector<boost::filesystem::path> findObsolete(
+        const std::vector<boost::filesystem::path>& candidates,
+        const std::set<std::string>& selected,
+        const std::set<std::string>& current
+    );
+}
+
+#endif // OBSOLETE_H

--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+#include <boost/regex.hpp>
 #include <csignal>
 
 namespace bpo = boost::program_options;
@@ -148,6 +149,10 @@ int main(int argc, char *argv[])
     std::string orphans_regex_default = ".*\\.(zip|exe|bin|dmg|old|deb|tar\\.gz|pkg|sh|mp4)$"; // Limit to files with these extensions (".old" is for renamed older version files)
     std::string check_orphans_text = "Check for orphaned files (files found on local filesystem that are not found on GOG servers). Sets regular expression filter (Perl syntax) for files to check. If no argument is given then the regex defaults to '" + orphans_regex_default + "'";
 
+    // Create help text for --check-obsolete
+    std::string obsolete_regex_default = ".*\\.(zip|exe|bin|dmg|old|deb|tar\\.gz|pkg|sh|mp4|iso)$";
+    std::string check_obsolete_text = "Check for obsolete files (local files that GOG's current catalog no longer offers). The protected set is always the complete catalog: every platform, language and file type, regardless of what --platform, --language, --include or --exclude selected for this run. Always uses the live catalog and never the --use-cache copy. Sets regular expression filter (Perl syntax) for files to check. If no argument is given then the regex defaults to '" + obsolete_regex_default + "'";
+
     // Help text for subdir options
     std::string subdir_help_text = "\nTemplates:\n"
         "- %platform%\n"
@@ -254,6 +259,8 @@ int main(int argc, char *argv[])
             ("clear-update-flags", bpo::value<bool>(&bClearUpdateNotifications)->zero_tokens()->default_value(false), "Clear update notification flags")
             ("check-orphans", bpo::value<std::string>(&Globals::globalConfig.sOrphanRegex)->implicit_value(""), check_orphans_text.c_str())
             ("delete-orphans", bpo::value<bool>(&Globals::globalConfig.dlConf.bDeleteOrphans)->zero_tokens()->default_value(false), "Delete orphaned files during --check-orphans and --galaxy-install")
+            ("check-obsolete", bpo::value<std::string>(&Globals::globalConfig.sObsoleteRegex)->implicit_value(""), check_obsolete_text.c_str())
+            ("delete-obsolete", bpo::value<bool>(&Globals::globalConfig.dlConf.bDeleteObsolete)->zero_tokens()->default_value(false), "Delete obsolete files during --check-obsolete after verifying the selected current files in each game directory")
             ("status", bpo::value<bool>(&Globals::globalConfig.bCheckStatus)->zero_tokens()->default_value(false), "Show status of files\n\nOutput format:\nstatuscode gamename filename filesize filehash\n\nStatus codes:\nOK - File is OK\nND - File is not downloaded\nMD5 - MD5 mismatch, different version\nFS - File size mismatch, incomplete download\n\nSee also --no-fast-status-check option")
             ("save-config", bpo::value<bool>(&Globals::globalConfig.bSaveConfig)->zero_tokens()->default_value(false), "Create config file with current settings")
             ("reset-config", bpo::value<bool>(&Globals::globalConfig.bResetConfig)->zero_tokens()->default_value(false), "Reset config settings to default")
@@ -358,6 +365,12 @@ int main(int argc, char *argv[])
         options_cli_all_include_hidden.add(options_cli_all).add(options_cli_no_cfg_hidden);
 
         bpo::parsed_options parsed = bpo::parse_command_line(argc, argv, options_cli_all_include_hidden);
+        bool bUseCacheFromCommandLine = false;
+        for (const auto& option : parsed.options)
+        {
+            if (option.string_key == "use-cache")
+                bUseCacheFromCommandLine = true;
+        }
         bpo::store(parsed, vm);
         unrecognized_options_cli = bpo::collect_unrecognized(parsed.options, bpo::include_positional);
         bpo::notify(vm);
@@ -523,6 +536,51 @@ int main(int argc, char *argv[])
         if (vm.count("check-orphans"))
             if (Globals::globalConfig.sOrphanRegex.empty())
                 Globals::globalConfig.sOrphanRegex = orphans_regex_default;
+
+        if (vm.count("check-obsolete"))
+        {
+            if (Globals::globalConfig.sObsoleteRegex.empty())
+                Globals::globalConfig.sObsoleteRegex = obsolete_regex_default;
+
+            // Reject a bad expression now. Resolving the catalog the check needs takes
+            // minutes on a large library, and it would all be thrown away.
+            try
+            {
+                boost::regex expression(Globals::globalConfig.sObsoleteRegex);
+            }
+            catch (const boost::regex_error& ex)
+            {
+                std::cerr << "Invalid --check-obsolete regular expression: " << ex.what() << std::endl;
+                return 1;
+            }
+        }
+
+        if (vm.count("check-orphans") && vm.count("check-obsolete"))
+        {
+            std::cerr << "--check-orphans and --check-obsolete cannot be used together" << std::endl;
+            return 1;
+        }
+
+        if (Globals::globalConfig.dlConf.bDeleteObsolete && !vm.count("check-obsolete"))
+        {
+            std::cerr << "--delete-obsolete requires --check-obsolete" << std::endl;
+            return 1;
+        }
+
+        if (vm.count("check-obsolete") && Globals::globalConfig.bUseCache)
+        {
+            // Only refuse when the user asked for the cache on the command line.
+            // use-cache is also a config file setting, and there is no way to negate
+            // it from the command line, so honouring it here would make
+            // --check-obsolete permanently unreachable for that user.
+            if (bUseCacheFromCommandLine)
+            {
+                std::cerr << "--check-obsolete requires live catalog metadata and cannot be used with --use-cache" << std::endl;
+                return 1;
+            }
+            std::cerr << "--check-obsolete requires live catalog metadata; ignoring use-cache for this run" << std::endl;
+            Globals::globalConfig.bUseCache = false;
+        }
 
         if (vm.count("report"))
             Globals::globalConfig.bReport = true;
@@ -819,6 +877,24 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    // Every branch below is exclusive, so an obsolete check requested alongside an
+    // action that outranks it would silently do nothing while still paying for the
+    // widened catalog resolution. Say so instead of reporting an empty result.
+    if (!Globals::globalConfig.sObsoleteRegex.empty()
+        && !Globals::globalConfig.bDownload && !Globals::globalConfig.bRepair
+        && (Globals::globalConfig.bUpdateCache || Globals::globalConfig.bNotifications
+            || bClearUpdateNotifications || !vFileIdStrings.empty() || bList
+            || Globals::globalConfig.bCheckStatus
+            || !galaxy_product_id_show_builds.empty() || !galaxy_product_id_install.empty()
+            || !galaxy_product_id_list_cdns.empty() || !galaxy_product_id_show_cloud_paths.empty()
+            || !galaxy_product_id_show_local_cloud_paths.empty()
+            || !galaxy_product_cloud_saves_delete.empty()
+            || !galaxy_upload_product_cloud_saves.empty()))
+    {
+        std::cerr << "--check-obsolete must be used on its own or together with --download or --repair" << std::endl;
+        return 1;
+    }
+
     int res = 0;
 
     if (Globals::globalConfig.bUpdateCache)
@@ -842,6 +918,8 @@ int main(int argc, char *argv[])
         res = downloader.listGames();
     else if (!Globals::globalConfig.sOrphanRegex.empty()) // Check for orphaned files if regex for orphans is set
         downloader.checkOrphans();
+    else if (!Globals::globalConfig.sObsoleteRegex.empty()) // Check against the current catalog
+        res = downloader.checkObsolete();
     else if (Globals::globalConfig.bCheckStatus)
         downloader.checkStatus();
     else if (!galaxy_product_id_show_builds.empty())
@@ -943,6 +1021,12 @@ int main(int argc, char *argv[])
     // Orphan check was called at the same time as download. Perform it after download has finished
     if (!Globals::globalConfig.sOrphanRegex.empty() && Globals::globalConfig.bDownload)
         downloader.checkOrphans();
+
+    // Obsolete check was requested alongside another action. Perform it once that
+    // action has finished, so the check sees the files it just wrote.
+    if (!Globals::globalConfig.sObsoleteRegex.empty()
+        && (Globals::globalConfig.bDownload || Globals::globalConfig.bRepair))
+        res |= downloader.checkObsolete();
 
     return res;
 }

--- a/man/lgogdownloader.1
+++ b/man/lgogdownloader.1
@@ -96,6 +96,47 @@ then the regex defaults to \&'.*\e.(zip|exe|bin|dmg|old|deb|tar\e.gz|pkg|sh|mp4)
 Delete orphaned files during
 \fB\-\-check\-orphans\fR and \fB\-\-galaxy\-install\fR
 .TP
+\fB\-\-check\-obsolete\fR arg
+Check for obsolete files: files found on the local filesystem that GOG's current
+catalog no longer offers. The protected set is always the complete catalog \(em
+every platform, every language and every file type \(em regardless of what
+\fB\-\-platform\fR, \fB\-\-language\fR, \fB\-\-include\fR or
+\fB\-\-exclude\fR selected for this run; those options still control what is
+downloaded and verified. Resolving all live platform, language and type metadata
+can take several minutes on a large library even when no payload files need
+downloading. Always uses the live catalog and never the \fB\-\-use\-cache\fR copy.
+Sets a Perl regular expression filter for files to check. If no argument is given,
+the default covers common GOG installer, patch, extra, and media formats.
+May be used on its own or together with \fB\-\-download\fR or \fB\-\-repair\fR.
+.TP
+\fB\-\-delete\-obsolete\fR
+Delete files reported by \fB\-\-check\-obsolete\fR. Before deleting from a game
+directory, all selected current files in that directory must exist and match the
+exact current download size and, for installers, patches and language packs, a
+freshly computed checksum; extras are verified by size alone. Deletion from a game
+directory is refused if size or checksum metadata cannot be retrieved, if the
+current catalog listed no file at all for that directory, if the run has no
+selected current file there to verify against, or if that game's catalog metadata
+came back incomplete. An incomplete response is never evidence that a local file is
+obsolete: the affected game is reported but never pruned, while the rest of the
+library is still checked.
+Verification is performed only for directories that actually have obsolete
+candidates. Blacklisted and ignorelisted files are not reported or deleted.
+This option requires \fB\-\-check\-obsolete\fR.
+.sp
+Two kinds of file cannot be described by the current catalog and are therefore
+reported as obsolete: files GOG lists for information only, and files of a DLC the
+account no longer owns. Neither has a resolvable download path, so a local copy
+cannot be matched against the catalog. Blacklist them if you keep such files.
+.sp
+A game is skipped when \fB%version%\fR appears in one of its directory templates,
+because the game root has no version of its own and would span every version
+directory while the catalog paths inside it are version specific.
+.sp
+\fB\-\-check\-obsolete\fR exits non-zero if any game was skipped or any game
+directory was refused, so a zero exit means the whole selection was checked. With
+\fB\-\-delete\-obsolete\fR it also exits non-zero if a deletion failed.
+.TP
 \fB\-\-status\fR
 Show status of files
 .sp 1

--- a/src/catalogmetadata.cpp
+++ b/src/catalogmetadata.cpp
@@ -1,0 +1,129 @@
+/* This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details. */
+
+#include "catalogmetadata.h"
+#include "globalconstants.h"
+
+#include <algorithm>
+#include <cctype>
+
+CatalogMetadata::ResolutionFailure CatalogMetadata::validateFileResolution(
+    const Json::Value& downlinkJson,
+    const std::string& resolvedPath
+)
+{
+    if (downlinkJson.isNull())
+        return ResolutionFailure::EmptyResponse;
+    if (!downlinkJson.isObject())
+        return ResolutionFailure::MalformedResponse;
+    if (!downlinkJson.isMember("downlink") || !downlinkJson["downlink"].isString()
+        || downlinkJson["downlink"].asString().empty())
+        return ResolutionFailure::MissingDownlink;
+    if (resolvedPath.empty())
+        return ResolutionFailure::EmptyPath;
+
+    std::string lowercase_path = resolvedPath;
+    std::transform(lowercase_path.begin(), lowercase_path.end(), lowercase_path.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    const auto ends_with = [&lowercase_path](const std::string& suffix) {
+        return lowercase_path.size() >= suffix.size()
+            && lowercase_path.compare(lowercase_path.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+    if (ends_with("/secure") || ends_with("/securex"))
+        return ResolutionFailure::InvalidPath;
+
+    return ResolutionFailure::None;
+}
+
+unsigned int CatalogMetadata::countMissingDownloadSections(
+    const Json::Value& productJson,
+    const unsigned int& includeTypes
+)
+{
+    if (!productJson.isObject() || !productJson.isMember("downloads")
+        || !productJson["downloads"].isObject())
+        return 1;
+
+    const Json::Value& downloads = productJson["downloads"];
+    unsigned int missing = 0;
+    const auto require_array = [&downloads, &missing](const char* name) {
+        if (!downloads.isMember(name) || !downloads[name].isArray())
+            missing++;
+    };
+
+    if (includeTypes & GlobalConstants::GFTYPE_INSTALLER)
+        require_array("installers");
+    if (includeTypes & GlobalConstants::GFTYPE_EXTRA)
+        require_array("bonus_content");
+    if (includeTypes & GlobalConstants::GFTYPE_PATCH)
+        require_array("patches");
+    if (includeTypes & GlobalConstants::GFTYPE_LANGPACK)
+        require_array("language_packs");
+
+    return missing;
+}
+
+bool CatalogMetadata::hasCompleteDlcExpansion(const Json::Value& productJson)
+{
+    if (!productJson.isObject())
+        return false;
+    return !productJson["dlcs"].isObject() || productJson["expanded_dlcs"].isArray();
+}
+
+bool CatalogMetadata::hasCompleteDownloadGroup(const Json::Value& group, bool requirePlatformLanguage)
+{
+    if (!group.isObject())
+        return false;
+
+    const bool has_files = group.isMember("files") && group["files"].isArray()
+        && !group["files"].empty();
+    if (!has_files)
+        return isEmptyDownloadGroup(group);
+
+    if (requirePlatformLanguage
+        && (!group.isMember("os") || !group["os"].isString() || group["os"].asString().empty()
+            || !group.isMember("language") || !group["language"].isString()
+            || group["language"].asString().empty()))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool CatalogMetadata::isEmptyDownloadGroup(const Json::Value& group)
+{
+    if (!group.isObject())
+        return false;
+
+    // Upstream reads these with asUInt()/asLargestUInt(), which coerce an absent or
+    // null value to zero. Match that, so this predicate classifies exactly the
+    // groups upstream skips and no others.
+    const auto readsAsZero = [&group](const char* name) {
+        const Json::Value& value = group[name];
+        return value.isNull() || (value.isNumeric() && value.asLargestUInt() == 0);
+    };
+
+    return readsAsZero("total_size") && readsAsZero("count");
+}
+
+bool CatalogMetadata::hasCompleteFileEntry(const Json::Value& file)
+{
+    if (!file.isObject() || !file.isMember("downlink") || !file["downlink"].isString()
+        || file["downlink"].asString().empty() || !file.isMember("size"))
+    {
+        return false;
+    }
+
+    const Json::Value& size = file["size"];
+    return size.isNumeric() || (size.isString() && !size.asString().empty());
+}
+
+std::string CatalogMetadata::scalarString(const Json::Value& value)
+{
+    return value.isString() || value.isNumeric() ? value.asString() : std::string();
+}

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -10,6 +10,7 @@
 #include "downloadinfo.h"
 #include "message.h"
 #include "ziputil.h"
+#include "obsolete.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -30,6 +31,9 @@
 #include <mutex>
 #include <atomic>
 #include <memory>
+#include <set>
+#include <map>
+#include <iterator>
 
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>
@@ -53,6 +57,7 @@ ThreadSafeQueue<Message> msgQueue;
 ThreadSafeQueue<gameFile> createXMLQueue;
 ThreadSafeQueue<gameItem> gameItemQueue;
 ThreadSafeQueue<gameDetails> gameDetailsQueue;
+ThreadSafeQueue<gameDetails> currentCatalogGameDetailsQueue;
 ThreadSafeQueue<galaxyDepotItem> dlQueueGalaxy;
 ThreadSafeQueue<zipFileEntry> dlQueueGalaxy_MojoSetupHack;
 std::mutex mtx_create_directories; // Mutex for creating directories in Downloader::processDownloadQueue
@@ -501,6 +506,12 @@ int Downloader::getGameDetails()
             this->games.push_back(details);
         }
         std::sort(this->games.begin(), this->games.end(), [](const gameDetails& i, const gameDetails& j) -> bool { return i.gamename < j.gamename; });
+
+        while (currentCatalogGameDetailsQueue.try_pop(details))
+        {
+            this->currentCatalogGames.push_back(details);
+        }
+        std::sort(this->currentCatalogGames.begin(), this->currentCatalogGames.end(), [](const gameDetails& i, const gameDetails& j) -> bool { return i.gamename < j.gamename; });
     }
 
     return 0;
@@ -1828,6 +1839,462 @@ void Downloader::checkOrphans()
     return;
 }
 
+namespace
+{
+    struct ObsoleteGroup
+    {
+        boost::filesystem::path root;
+        std::set<std::string> selected;
+        std::set<std::string> current;
+        std::vector<gameFile> selected_files;
+        std::set<std::string> base_directories;
+        // Set when something about this root is not trustworthy enough to delete
+        // from it. Candidates are still reported, they are just never removed.
+        bool blocked = false;
+        std::string blocked_reason;
+    };
+
+    bool isProtectedPath(const boost::filesystem::path& path, const ObsoleteGroup& group, Config& config)
+    {
+        for (const auto& base_directory : group.base_directories)
+        {
+            const std::string relative_path = Obsolete::relativeKey(base_directory, path);
+
+            if (config.ignorelist.isBlacklisted(relative_path) || config.blacklist.isBlacklisted(relative_path))
+                return true;
+        }
+        return false;
+    }
+}
+
+int Downloader::checkObsolete()
+{
+    Config config = Globals::globalConfig;
+
+    if (this->games.empty())
+    {
+        if (this->getGameDetails() != 0)
+        {
+            std::cerr << "Failed to retrieve current game details; obsolete check aborted" << std::endl;
+            return 1;
+        }
+    }
+
+    if (!this->gameItems.empty() && this->games.size() != this->gameItems.size())
+    {
+        std::cerr << "Current metadata is incomplete (got " << this->games.size() << " of "
+                  << this->gameItems.size() << " games); obsolete check aborted" << std::endl;
+        return 1;
+    }
+
+    if (this->currentCatalogGames.size() != this->games.size())
+    {
+        std::cerr << "Current all-platform, all-language metadata is incomplete (got "
+                  << this->currentCatalogGames.size() << " of " << this->games.size()
+                  << " games); obsolete check aborted" << std::endl;
+        return 1;
+    }
+
+    // An incomplete catalog response is never evidence that a local file is
+    // obsolete. Quarantine the affected game instead of the whole library: its
+    // roots are still scanned and reported, but nothing is deleted from them.
+    std::set<std::string> incomplete_games;
+    size_t metadata_failures = 0;
+    for (const auto& game : this->currentCatalogGames)
+    {
+        if (game.metadataFailures == 0)
+            continue;
+        std::cerr << game.gamename << ": encountered " << game.metadataFailures
+                  << " current catalog metadata failure" << (game.metadataFailures == 1 ? "" : "s")
+                  << "; nothing will be deleted for this game" << std::endl;
+        incomplete_games.insert(game.gamename);
+        metadata_failures += game.metadataFailures;
+    }
+    if (metadata_failures > 0)
+    {
+        std::cerr << "Current catalog metadata is incomplete for " << incomplete_games.size()
+                  << " game" << (incomplete_games.size() == 1 ? "" : "s") << " (" << metadata_failures
+                  << " failure" << (metadata_failures == 1 ? "" : "s")
+                  << "); those games are reported but never pruned" << std::endl;
+    }
+
+    std::map<std::string, gameDetails*> current_catalog;
+    for (auto& game : this->currentCatalogGames)
+        current_catalog[game.gamename] = &game;
+
+    boost::regex expression;
+    try
+    {
+        expression.assign(config.sObsoleteRegex);
+    }
+    catch (const boost::regex_error& ex)
+    {
+        std::cerr << "Invalid --check-obsolete regular expression: " << ex.what() << std::endl;
+        return 1;
+    }
+
+    std::map<std::string, ObsoleteGroup> groups;
+    bool setup_failed = false;
+    bool skipped_games = !incomplete_games.empty();
+
+    for (auto& game : this->games)
+    {
+        if (game.gamename.empty())
+        {
+            std::cerr << "Received incomplete product metadata; obsolete check aborted" << std::endl;
+            setup_failed = true;
+            continue;
+        }
+
+        const auto current_game = current_catalog.find(game.gamename);
+        if (current_game == current_catalog.end())
+        {
+            std::cerr << game.gamename << ": current all-platform, all-language metadata is missing; obsolete check aborted" << std::endl;
+            setup_failed = true;
+            continue;
+        }
+
+        gameSpecificConfig conf;
+        conf.dlConf = config.dlConf;
+        conf.dirConf = config.dirConf;
+        Util::getGameSpecificConfig(game.gamename, &conf);
+
+        const boost::filesystem::path base_directory = boost::filesystem::absolute(conf.dirConf.sDirectory).lexically_normal();
+        const std::string base_key = Obsolete::pathKey(base_directory);
+
+        // The synthetic gameFile a game root is built from carries no version, so a
+        // %version% template makes the root version agnostic while the catalog paths
+        // under it are version specific. Everything left at a previous version's path
+        // would then look obsolete, including variants this run does not download and
+        // whose content GOG still offers unchanged. Refuse rather than guess.
+        const std::vector<std::string> directory_templates = {
+            conf.dirConf.sDirectory, conf.dirConf.sGameSubdir, conf.dirConf.sInstallersSubdir,
+            conf.dirConf.sExtrasSubdir, conf.dirConf.sPatchesSubdir,
+            conf.dirConf.sLanguagePackSubdir, conf.dirConf.sDLCSubdir
+        };
+        bool uses_version_template = false;
+        for (const auto& directory_template : directory_templates)
+        {
+            if (directory_template.find("%version%") != std::string::npos)
+                uses_version_template = true;
+        }
+        if (uses_version_template)
+        {
+            std::cerr << game.gamename << ": %version% in a directory template makes the game root"
+                      << " version agnostic; skipping this game" << std::endl;
+            skipped_games = true;
+            continue;
+        }
+
+        std::vector<boost::filesystem::path> roots;
+        std::vector<unsigned int> platform_ids = {0};
+        for (const auto& platform : GlobalConstants::PLATFORMS)
+            platform_ids.push_back(platform.id);
+
+        bool root_is_download_directory = false;
+        for (const auto platform : platform_ids)
+        {
+            boost::filesystem::path root(game.makeCustomFilepath("", game, conf.dirConf, platform));
+            root = boost::filesystem::path(Obsolete::pathKey(root));
+            if (Obsolete::pathKey(root) == base_key)
+            {
+                root_is_download_directory = true;
+                continue;
+            }
+
+            bool covered = false;
+            for (const auto& existing : roots)
+            {
+                if (Obsolete::isWithin(existing, root))
+                {
+                    covered = true;
+                    break;
+                }
+            }
+            if (!covered)
+            {
+                roots.erase(
+                    std::remove_if(roots.begin(), roots.end(), [&root](const boost::filesystem::path& existing) {
+                        return Obsolete::isWithin(root, existing);
+                    }),
+                    roots.end()
+                );
+                roots.push_back(root);
+            }
+        }
+
+        if (root_is_download_directory)
+        {
+            // Nothing separates this game's files from the rest of the library,
+            // so there is no directory that can be pruned on its behalf.
+            std::cerr << game.gamename << ": game root is the entire download directory "
+                      << base_directory.string() << "; skipping this game" << std::endl;
+            skipped_games = true;
+            continue;
+        }
+
+        if (roots.empty())
+            continue;
+
+        for (const auto& root : roots)
+        {
+            const std::string root_key = Obsolete::pathKey(root);
+            auto& group = groups[root_key];
+            group.root = root;
+            group.base_directories.insert(base_key);
+            if (incomplete_games.count(game.gamename) > 0)
+            {
+                group.blocked = true;
+                group.blocked_reason = "current catalog metadata for " + game.gamename + " is incomplete";
+            }
+        }
+
+        for (const auto& gf : game.getGameFileVector())
+        {
+            const boost::filesystem::path wanted_path = boost::filesystem::absolute(gf.getFilepath()).lexically_normal();
+            bool assigned = false;
+            for (const auto& root : roots)
+            {
+                if (!Obsolete::isWithin(root, wanted_path))
+                    continue;
+
+                auto& group = groups[Obsolete::pathKey(root)];
+                if (!isProtectedPath(wanted_path, group, config))
+                {
+                    group.selected.insert(Obsolete::pathKey(wanted_path));
+                    group.selected_files.push_back(gf);
+                }
+                assigned = true;
+                break;
+            }
+
+            if (!assigned)
+            {
+                std::cerr << game.gamename << ": selected file is outside its game root: "
+                          << wanted_path.string() << std::endl;
+                setup_failed = true;
+            }
+        }
+
+        for (const auto& gf : current_game->second->getGameFileVector())
+        {
+            const boost::filesystem::path current_path = boost::filesystem::absolute(gf.getFilepath()).lexically_normal();
+            bool assigned = false;
+            for (const auto& root : roots)
+            {
+                if (!Obsolete::isWithin(root, current_path))
+                    continue;
+
+                auto& group = groups[Obsolete::pathKey(root)];
+                if (!isProtectedPath(current_path, group, config))
+                    group.current.insert(Obsolete::pathKey(current_path));
+                assigned = true;
+                break;
+            }
+
+            if (!assigned)
+            {
+                std::cerr << game.gamename << ": current catalog file is outside its game root: "
+                          << current_path.string() << std::endl;
+                setup_failed = true;
+            }
+        }
+    }
+
+    // Overlapping roots owned by different groups make ownership ambiguous. Refuse instead of
+    // allowing a broad root to classify files from a nested game as obsolete.
+    for (auto first = groups.begin(); first != groups.end(); ++first)
+    {
+        for (auto second = std::next(first); second != groups.end(); ++second)
+        {
+            if (Obsolete::isWithin(first->second.root, second->second.root)
+                || Obsolete::isWithin(second->second.root, first->second.root))
+            {
+                std::cerr << "Overlapping game roots are not safe to prune: " << first->second.root.string()
+                          << " and " << second->second.root.string() << std::endl;
+                setup_failed = true;
+            }
+        }
+    }
+
+    if (setup_failed)
+    {
+        std::cerr << "Obsolete check aborted before scanning; no files were deleted" << std::endl;
+        return 1;
+    }
+
+    bool failed = false;
+    size_t obsolete_count = 0;
+    size_t deleted_count = 0;
+
+    for (auto& entry : groups)
+    {
+        auto& group = entry.second;
+        std::vector<boost::filesystem::path> candidates;
+        try
+        {
+            candidates = Obsolete::collectCandidates(group.root, expression);
+        }
+        catch (const boost::filesystem::filesystem_error& ex)
+        {
+            std::cerr << ex.what() << std::endl;
+            failed = true;
+            continue;
+        }
+
+        candidates.erase(
+            std::remove_if(candidates.begin(), candidates.end(), [&group, &config](const boost::filesystem::path& path) {
+                return isProtectedPath(path, group, config);
+            }),
+            candidates.end()
+        );
+
+        auto obsolete = Obsolete::findObsolete(candidates, group.selected, group.current);
+        obsolete_count += obsolete.size();
+
+        // Reporting only needs the live selected path set. The expensive local
+        // verification gate is required only when this group has files to delete.
+        bool verified = true;
+        if (!obsolete.empty())
+        {
+            // These say why the candidates below are not trustworthy evidence, so
+            // report them whether or not this run would delete anything.
+            const std::string consequence = config.dlConf.bDeleteObsolete
+                ? "; no obsolete files were deleted from it"
+                : "; the candidates below are not evidence of obsolescence";
+
+            if (group.blocked)
+            {
+                std::cerr << group.root.string() << ": " << group.blocked_reason
+                          << consequence << std::endl;
+                verified = false;
+            }
+            else if (group.current.empty())
+            {
+                // The live catalog described no file at all under this root. That is
+                // never evidence that everything on disk is superseded.
+                std::cerr << group.root.string() << ": the current catalog lists no files for this game root"
+                          << consequence << std::endl;
+                verified = false;
+                failed = true;
+            }
+            else if (config.dlConf.bDeleteObsolete && group.selected_files.empty())
+            {
+                // Without a selected current file there is nothing local to verify
+                // against, so the documented pre-delete gate cannot be applied.
+                std::cerr << group.root.string() << ": no selected current file to verify against"
+                          << consequence << std::endl;
+                verified = false;
+                failed = true;
+            }
+        }
+        if (verified && config.dlConf.bDeleteObsolete && !obsolete.empty())
+        {
+            for (const auto& gf : group.selected_files)
+            {
+                const boost::filesystem::path filepath = boost::filesystem::absolute(gf.getFilepath()).lexically_normal();
+                uintmax_t expected_size = 0;
+                std::string remote_hash;
+                if (!boost::filesystem::exists(filepath) || !boost::filesystem::is_regular_file(filepath))
+                {
+                    std::cerr << gf.gamename << ": selected current file is missing: " << filepath.string() << std::endl;
+                    verified = false;
+                    continue;
+                }
+                // Nothing can be deleted from this root any more, so skip the
+                // remaining requests and full-file checksums.
+                if (!verified)
+                    continue;
+                if (!this->getRemoteFileVerification(gf, expected_size, remote_hash))
+                {
+                    std::cerr << gf.gamename << ": current file has no trustworthy remote verification data: "
+                              << filepath.string() << std::endl;
+                    verified = false;
+                    continue;
+                }
+                const uintmax_t actual_size = boost::filesystem::file_size(filepath);
+                if (actual_size != expected_size)
+                {
+                    std::cerr << gf.gamename << ": selected current file has wrong size: " << filepath.string()
+                              << " (local " << actual_size << ", remote " << expected_size << ")" << std::endl;
+                    verified = false;
+                    continue;
+                }
+
+                const bool checksum_required = gf.type & (GlobalConstants::GFTYPE_INSTALLER
+                    | GlobalConstants::GFTYPE_PATCH | GlobalConstants::GFTYPE_LANGPACK);
+                if (checksum_required && remote_hash.empty())
+                {
+                    std::cerr << gf.gamename << ": checksum metadata is unavailable for selected current file: "
+                              << filepath.string() << std::endl;
+                    verified = false;
+                }
+                else if (checksum_required)
+                {
+                    const std::string local_hash = Util::getLocalFileHash(
+                        config.sXMLDirectory,
+                        filepath.string(),
+                        gf.gamename,
+                        false
+                    );
+                    if (local_hash.empty() || local_hash != remote_hash)
+                    {
+                        std::cerr << gf.gamename << ": selected current file failed checksum verification: "
+                                  << filepath.string() << std::endl;
+                        verified = false;
+                    }
+                }
+            }
+        }
+
+        for (const auto& path : obsolete)
+        {
+            if (config.dlConf.bDeleteObsolete && verified)
+            {
+                boost::system::error_code ec;
+                const bool removed = boost::filesystem::remove(path, ec);
+                if (!removed || ec)
+                {
+                    std::cerr << "Failed to delete obsolete file " << path.string();
+                    if (ec)
+                        std::cerr << ": " << ec.message();
+                    std::cerr << std::endl;
+                    failed = true;
+                }
+                else
+                {
+                    std::cout << "Deleted obsolete file " << path.string() << std::endl;
+                    deleted_count++;
+                }
+            }
+            else if (config.dlConf.bDeleteObsolete)
+            {
+                std::cout << "Not deleting unverified obsolete candidate " << path.string() << std::endl;
+            }
+            else
+            {
+                std::cout << path.string() << std::endl;
+            }
+        }
+
+        if (!verified && !group.blocked && !group.current.empty() && !group.selected_files.empty())
+        {
+            std::cerr << "Selected current files under " << group.root.string()
+                      << " are incomplete; no obsolete files were deleted from this game root" << std::endl;
+            failed = true;
+        }
+    }
+
+    if (obsolete_count == 0)
+        std::cout << "No obsolete files" << std::endl;
+    else if (config.dlConf.bDeleteObsolete)
+        std::cout << "Deleted " << deleted_count << " of " << obsolete_count << " obsolete files" << std::endl;
+
+    // A skipped game means the run did not cover the whole selection, so do not
+    // report success even though everything it did check was fine.
+    return (failed || skipped_games) ? 1 : 0;
+}
+
 // Check status of files
 void Downloader::checkStatus()
 {
@@ -1967,7 +2434,19 @@ std::string Downloader::getLocalFileHash(const std::string& filepath, const std:
 
 std::string Downloader::getRemoteFileHash(const gameFile& gf)
 {
+    uintmax_t remoteSize = 0;
     std::string remoteHash;
+    // Callers that only want the hash must not pay for the Content-Length probe.
+    this->getRemoteFileVerification(gf, remoteSize, remoteHash, false);
+    return remoteHash;
+}
+
+bool Downloader::getRemoteFileVerification(const gameFile& gf, uintmax_t& remoteSize, std::string& remoteHash, const bool& bNeedSize)
+{
+    // Catalog sizes are rounded for some files. Use checksum XML or the current
+    // download's Content-Length so deletion is gated by the exact byte count.
+    remoteSize = 0;
+    remoteHash.clear();
 
     // Refresh Galaxy login if token is expired
     if (gogGalaxy->isTokenExpired())
@@ -1975,7 +2454,7 @@ std::string Downloader::getRemoteFileHash(const gameFile& gf)
         if (!gogGalaxy->refreshLogin())
         {
             std::cerr << "Galaxy API failed to refresh login" << std::endl;
-            return remoteHash;
+            return false;
         }
     }
 
@@ -1985,7 +2464,7 @@ std::string Downloader::getRemoteFileHash(const gameFile& gf)
     if (downlinkJson.empty())
     {
         std::cerr << "Empty JSON response" << std::endl;
-        return remoteHash;
+        return false;
     }
 
     std::string xml_url;
@@ -2005,11 +2484,44 @@ std::string Downloader::getRemoteFileHash(const gameFile& gf)
         tinyxml2::XMLElement *fileElemRemote = remote_xml.FirstChildElement("file");
         if (fileElemRemote)
         {
-            remoteHash = fileElemRemote->Attribute("md5");
+            const char* hash = fileElemRemote->Attribute("md5");
+            if (hash)
+                remoteHash = hash;
+            const char* total_size = fileElemRemote->Attribute("total_size");
+            if (total_size)
+            {
+                try
+                {
+                    remoteSize = std::stoull(total_size);
+                }
+                catch (const std::exception&)
+                {
+                    remoteSize = 0;
+                }
+            }
         }
     }
 
-    return remoteHash;
+    if (bNeedSize && remoteSize == 0 && downlinkJson.isMember("downlink") && !downlinkJson["downlink"].empty())
+    {
+        CURL* curlheader = curl_easy_init();
+        if (curlheader)
+        {
+            Util::CurlHandleSetDefaultOptions(curlheader, Globals::globalConfig.curlConf);
+            curl_easy_setopt(curlheader, CURLOPT_NOPROGRESS, 1L);
+            curl_easy_setopt(curlheader, CURLOPT_NOBODY, 1L);
+            curl_easy_setopt(curlheader, CURLOPT_URL, downlinkJson["downlink"].asCString());
+            const CURLcode result = curl_easy_perform(curlheader);
+            curl_off_t content_length = 0;
+            if (result == CURLE_OK)
+                curl_easy_getinfo(curlheader, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &content_length);
+            curl_easy_cleanup(curlheader);
+            if (content_length > 0)
+                remoteSize = static_cast<uintmax_t>(content_length);
+        }
+    }
+
+    return remoteSize > 0;
 }
 
 /* Load game details from cache file
@@ -3743,7 +4255,41 @@ void Downloader::getGameDetailsThread(Config config, const unsigned int& tid)
         }
 
         Json::Value product_info = galaxy->getProductInfo(game_item.id);
-        game = galaxy->productInfoJsonToGameDetails(product_info, conf.dlConf);
+        gameDetails current_catalog_game;
+        if (!config.sObsoleteRegex.empty())
+        {
+            // The set that protects local files must be the whole catalog, not the
+            // download selection. Anything narrower would classify a file GOG still
+            // offers as obsolete just because this run wasn't asked to download it.
+            // Same widening that checkOrphans applies before it deletes anything.
+            DownloadConfig current_catalog_conf = conf.dlConf;
+            current_catalog_conf.iInclude = Util::getOptionValue("all", GlobalConstants::INCLUDE_OPTIONS);
+            current_catalog_conf.iInstallerPlatform = Util::getOptionValue("all", GlobalConstants::PLATFORMS);
+            current_catalog_conf.iInstallerLanguage = Util::getOptionValue("all", GlobalConstants::LANGUAGES);
+            current_catalog_conf.vPlatformPriority.clear();
+            current_catalog_conf.vLanguagePriority.clear();
+            // Keep every variant distinct until after applying the download selection.
+            // Otherwise an earlier non-selected language with the same path can donate
+            // its downlink to the selected variant.
+            current_catalog_conf.bDuplicateHandler = false;
+
+            current_catalog_game = galaxy->productInfoJsonToGameDetails(product_info, current_catalog_conf);
+            game = current_catalog_game;
+            game.filterWithPlatformLanguage(conf.dlConf);
+            if (conf.dlConf.bDuplicateHandler)
+                game.filterDuplicates();
+        }
+        else
+        {
+            game = galaxy->productInfoJsonToGameDetails(product_info, conf.dlConf);
+        }
+        if (!config.sObsoleteRegex.empty())
+        {
+            // This branch derived game from the whole catalog, so drop the DLCs that
+            // productInfoJsonToGameDetails would never have added for this selection.
+            // Done before the remaining filters so both paths see the same input.
+            game.filterDlcsWithInclude(conf.dlConf.iInclude);
+        }
         game.filterWithPriorities(conf);
         game.filterWithType(conf.dlConf.iInclude);
 
@@ -3783,6 +4329,11 @@ void Downloader::getGameDetailsThread(Config config, const unsigned int& tid)
         }
 
         game.makeFilepaths(conf.dirConf);
+        if (!config.sObsoleteRegex.empty())
+        {
+            current_catalog_game.makeFilepaths(conf.dirConf);
+            currentCatalogGameDetailsQueue.push(current_catalog_game);
+        }
         gameDetailsQueue.push(game);
     }
 

--- a/src/galaxyapi.cpp
+++ b/src/galaxyapi.cpp
@@ -5,6 +5,7 @@
  * http://www.wtfpl.net/ for more details. */
 
 #include "galaxyapi.h"
+#include "catalogmetadata.h"
 #include "message.h"
 #include "ziputil.h"
 
@@ -370,10 +371,27 @@ Json::Value galaxyAPI::getProductInfo(const std::string& product_id)
 gameDetails galaxyAPI::productInfoJsonToGameDetails(const Json::Value& json, const DownloadConfig& dlConf)
 {
     gameDetails gamedetails;
+    if (!json.isObject())
+    {
+        gamedetails.metadataFailures++;
+        return gamedetails;
+    }
 
-    gamedetails.gamename = json["slug"].asString();
-    gamedetails.product_id = json["id"].asString();
-    gamedetails.title = json["title"].asString();
+    gamedetails.gamename = CatalogMetadata::scalarString(json["slug"]);
+    gamedetails.product_id = CatalogMetadata::scalarString(json["id"]);
+    gamedetails.title = CatalogMetadata::scalarString(json["title"]);
+
+    const unsigned int missing_download_sections = CatalogMetadata::countMissingDownloadSections(json, dlConf.iInclude);
+    gamedetails.metadataFailures += missing_download_sections;
+    if (!json.isMember("downloads") || !json["downloads"].isObject())
+        return gamedetails;
+
+    if ((dlConf.iInclude & GlobalConstants::GFTYPE_DLC)
+        && !CatalogMetadata::hasCompleteDlcExpansion(json))
+    {
+        gamedetails.metadataFailures++;
+    }
+
     gamedetails.icon = "https:" + json["images"]["icon"].asString();
     gamedetails.logo = "https:" + json["images"]["logo"].asString();
 
@@ -384,39 +402,45 @@ gameDetails galaxyAPI::productInfoJsonToGameDetails(const Json::Value& json, con
 
     if (dlConf.iInclude & GlobalConstants::GFTYPE_INSTALLER)
     {
-        gamedetails.installers = this->fileJsonNodeToGameFileVector(gamedetails.gamename, json["downloads"]["installers"], GlobalConstants::GFTYPE_BASE_INSTALLER, dlConf);
+        gamedetails.installers = this->fileJsonNodeToGameFileVector(gamedetails.gamename, json["downloads"]["installers"], GlobalConstants::GFTYPE_BASE_INSTALLER, dlConf, gamedetails.metadataFailures);
         for (auto &item : gamedetails.installers)
             item.title = gamedetails.title;
     }
 
     if (dlConf.iInclude & GlobalConstants::GFTYPE_EXTRA)
     {
-        gamedetails.extras = this->fileJsonNodeToGameFileVector(gamedetails.gamename, json["downloads"]["bonus_content"], GlobalConstants::GFTYPE_BASE_EXTRA, dlConf);
+        gamedetails.extras = this->fileJsonNodeToGameFileVector(gamedetails.gamename, json["downloads"]["bonus_content"], GlobalConstants::GFTYPE_BASE_EXTRA, dlConf, gamedetails.metadataFailures);
         for (auto &item : gamedetails.extras)
             item.title = gamedetails.title;
     }
 
     if (dlConf.iInclude & GlobalConstants::GFTYPE_PATCH)
     {
-        gamedetails.patches = this->fileJsonNodeToGameFileVector(gamedetails.gamename, json["downloads"]["patches"], GlobalConstants::GFTYPE_BASE_PATCH, dlConf);
+        gamedetails.patches = this->fileJsonNodeToGameFileVector(gamedetails.gamename, json["downloads"]["patches"], GlobalConstants::GFTYPE_BASE_PATCH, dlConf, gamedetails.metadataFailures);
         for (auto &item : gamedetails.patches)
             item.title = gamedetails.title;
     }
 
     if (dlConf.iInclude & GlobalConstants::GFTYPE_LANGPACK)
     {
-        gamedetails.languagepacks = this->fileJsonNodeToGameFileVector(gamedetails.gamename, json["downloads"]["language_packs"], GlobalConstants::GFTYPE_BASE_LANGPACK, dlConf);
+        gamedetails.languagepacks = this->fileJsonNodeToGameFileVector(gamedetails.gamename, json["downloads"]["language_packs"], GlobalConstants::GFTYPE_BASE_LANGPACK, dlConf, gamedetails.metadataFailures);
         for (auto &item : gamedetails.languagepacks)
             item.title = gamedetails.title;
     }
 
     if (dlConf.iInclude & GlobalConstants::GFTYPE_DLC)
     {
-        if (json.isMember("expanded_dlcs"))
+        if (json["expanded_dlcs"].isArray())
         {
             for (unsigned int i = 0; i < json["expanded_dlcs"].size(); ++i)
             {
-                std::string dlc_id = json["expanded_dlcs"][i]["id"].asString();
+                const Json::Value& dlc_json = json["expanded_dlcs"][i];
+                if (!dlc_json.isObject())
+                {
+                    gamedetails.metadataFailures++;
+                    continue;
+                }
+                std::string dlc_id = CatalogMetadata::scalarString(dlc_json["id"]);
 
                 if (!Globals::vOwnedGamesIds.empty())
                 {
@@ -424,7 +448,8 @@ gameDetails galaxyAPI::productInfoJsonToGameDetails(const Json::Value& json, con
                         continue;
                 }
 
-                gameDetails dlc_gamedetails = this->productInfoJsonToGameDetails(json["expanded_dlcs"][i], dlConf);
+                gameDetails dlc_gamedetails = this->productInfoJsonToGameDetails(dlc_json, dlConf);
+                gamedetails.metadataFailures += dlc_gamedetails.metadataFailures;
                 dlc_gamedetails.title_basegame = gamedetails.title;
                 dlc_gamedetails.gamename_basegame = gamedetails.gamename;
 
@@ -464,25 +489,48 @@ gameDetails galaxyAPI::productInfoJsonToGameDetails(const Json::Value& json, con
     return gamedetails;
 }
 
-std::vector<gameFile> galaxyAPI::fileJsonNodeToGameFileVector(const std::string& gamename, const Json::Value& json, const unsigned int& type, const DownloadConfig& dlConf)
+std::vector<gameFile> galaxyAPI::fileJsonNodeToGameFileVector(const std::string& gamename, const Json::Value& json, const unsigned int& type, const DownloadConfig& dlConf, unsigned int& metadataFailures)
 {
     std::vector<gameFile> gamefiles;
+    if (!json.isArray())
+    {
+        metadataFailures++;
+        return gamefiles;
+    }
+
     unsigned int iInfoNodes = json.size();
     for (unsigned int i = 0; i < iInfoNodes; ++i)
     {
         Json::Value infoNode = json[i];
-        unsigned int iFiles = infoNode["files"].size();
-        std::string name = infoNode["name"].asString();
+        const bool require_platform_language = !(type & GlobalConstants::GFTYPE_EXTRA);
+        if (!CatalogMetadata::hasCompleteDownloadGroup(infoNode, require_platform_language))
+        {
+            metadataFailures++;
+            continue;
+        }
+
+        // GOG uses an all-zero group as an empty placeholder.
+        // https://github.com/Sude-/lgogdownloader/issues/200
+        if (CatalogMetadata::isEmptyDownloadGroup(infoNode))
+            continue;
+
+        std::string name = infoNode["name"].isString() ? infoNode["name"].asString() : std::string();
         std::string version = "";
-        if (!infoNode["version"].empty())
+        if (infoNode["version"].isString())
             version = infoNode["version"].asString();
 
         unsigned int iPlatform = GlobalConstants::PLATFORM_WINDOWS;
         unsigned int iLanguage = GlobalConstants::LANGUAGE_EN;
-        if (!(type & GlobalConstants::GFTYPE_EXTRA))
+        if (require_platform_language)
         {
             iPlatform = Util::getOptionValue(infoNode["os"].asString(), GlobalConstants::PLATFORMS);
             iLanguage = Util::getOptionValue(infoNode["language"].asString(), GlobalConstants::LANGUAGES);
+
+            if (iPlatform == 0 || iLanguage == 0)
+            {
+                metadataFailures++;
+                continue;
+            }
 
             if (!(iPlatform & dlConf.iInstallerPlatform))
                 continue;
@@ -491,35 +539,43 @@ std::vector<gameFile> galaxyAPI::fileJsonNodeToGameFileVector(const std::string&
                 continue;
         }
 
-        // Skip file if count and total_size is zero
-        // https://github.com/Sude-/lgogdownloader/issues/200
-        unsigned int count = infoNode["count"].asUInt();
-        uintmax_t total_size = infoNode["total_size"].asLargestUInt();
-        if (count == 0 && total_size == 0)
-            continue;
-
+        unsigned int iFiles = infoNode["files"].size();
         for (unsigned int j = 0; j < iFiles; ++j)
         {
             Json::Value fileNode = infoNode["files"][j];
+            if (!CatalogMetadata::hasCompleteFileEntry(fileNode))
+            {
+                metadataFailures++;
+                continue;
+            }
             std::string downlink = fileNode["downlink"].asString();
 
+            // Util::CurlHandleGetResponse already retries what is worth retrying and
+            // deliberately does not retry 403/404, so resolve once and classify the
+            // result. Anything unresolved is recorded as a metadata failure, which is
+            // what stops an unresolved file from being read as "no longer offered".
             Json::Value downlinkJson = this->getResponseJson(downlink);
-            if (downlinkJson.empty())
-                continue;
+            std::string downlink_url;
+            std::string path;
+            if (downlinkJson.isObject() && downlinkJson.isMember("downlink")
+                && downlinkJson["downlink"].isString())
+            {
+                downlink_url = downlinkJson["downlink"].asString();
+                if (!downlink_url.empty())
+                    path = this->getPathFromDownlinkUrl(downlink_url, gamename);
+            }
 
-            std::string downlink_url = downlinkJson["downlink"].asString();
-            std::string path = this->getPathFromDownlinkUrl(downlink_url, gamename);
-
-            // Check to see if path ends in "/secure" or "/securex" which means that we got invalid path for some reason
-            boost::regex path_re("/securex?$", boost::regex::perl | boost::regex::icase);
-            boost::match_results<std::string::const_iterator> what;
-            if (boost::regex_search(path, what, path_re))
+            if (CatalogMetadata::validateFileResolution(downlinkJson, path)
+                != CatalogMetadata::ResolutionFailure::None)
+            {
+                metadataFailures++;
                 continue;
+            }
 
             gameFile gf;
             gf.gamename = gamename;
             gf.type = type;
-            gf.id = fileNode["id"].asString();
+            gf.id = CatalogMetadata::scalarString(fileNode["id"]);
             gf.name = name;
             gf.path = path;
             gf.size = Util::getJsonUIntValueAsString(fileNode["size"]);

--- a/src/gamedetails.cpp
+++ b/src/gamedetails.cpp
@@ -16,6 +16,91 @@ gameDetails::~gameDetails()
     //dtor
 }
 
+void gameDetails::filterWithPlatformLanguage(const DownloadConfig& config)
+{
+    filterListWithPlatformLanguage(installers, config);
+    filterListWithPlatformLanguage(patches, config);
+    filterListWithPlatformLanguage(languagepacks, config);
+    for (auto& dlc : dlcs)
+        dlc.filterWithPlatformLanguage(config);
+
+    dlcs.erase(
+        std::remove_if(dlcs.begin(), dlcs.end(), [](const gameDetails& dlc) {
+            return dlc.installers.empty() && dlc.patches.empty() && dlc.extras.empty()
+                && dlc.languagepacks.empty() && dlc.dlcs.empty();
+        }),
+        dlcs.end()
+    );
+}
+
+// galaxyAPI::productInfoJsonToGameDetails walks expanded_dlcs only when the include
+// selection asks for DLCs, and then adds a DLC only if it has a file in one of the
+// selected sections. Reproduce both conditions for details built from the whole
+// catalog, so the download selection is the same either way.
+void gameDetails::filterDlcsWithInclude(const unsigned int& iInclude)
+{
+    if (!(iInclude & GlobalConstants::GFTYPE_DLC))
+    {
+        dlcs.clear();
+        return;
+    }
+
+    for (auto& dlc : dlcs)
+        dlc.filterDlcsWithInclude(iInclude);
+
+    dlcs.erase(
+        std::remove_if(dlcs.begin(), dlcs.end(), [&iInclude](const gameDetails& dlc) {
+            const bool has_selected_section =
+                   ((iInclude & GlobalConstants::GFTYPE_INSTALLER) && !dlc.installers.empty())
+                || ((iInclude & GlobalConstants::GFTYPE_EXTRA) && !dlc.extras.empty())
+                || ((iInclude & GlobalConstants::GFTYPE_PATCH) && !dlc.patches.empty())
+                || ((iInclude & GlobalConstants::GFTYPE_LANGPACK) && !dlc.languagepacks.empty());
+            return !has_selected_section;
+        }),
+        dlcs.end()
+    );
+}
+
+void gameDetails::filterListWithPlatformLanguage(std::vector<gameFile>& list, const DownloadConfig& config)
+{
+    list.erase(
+        std::remove_if(list.begin(), list.end(), [&config](const gameFile& file) {
+            return !(file.platform & config.iInstallerPlatform)
+                || !(file.language & config.iInstallerLanguage);
+        }),
+        list.end()
+    );
+}
+
+void gameDetails::filterDuplicates()
+{
+    filterDuplicateList(installers);
+    filterDuplicateList(patches);
+    filterDuplicateList(extras);
+    filterDuplicateList(languagepacks);
+    for (auto& dlc : dlcs)
+        dlc.filterDuplicates();
+}
+
+void gameDetails::filterDuplicateList(std::vector<gameFile>& list)
+{
+    for (auto file = list.begin(); file != list.end();)
+    {
+        const auto duplicate = std::find_if(list.begin(), file, [&file](const gameFile& existing) {
+            return existing.path == file->path;
+        });
+        if (duplicate == file)
+        {
+            ++file;
+            continue;
+        }
+
+        if (!(file->type & GlobalConstants::GFTYPE_EXTRA))
+            duplicate->language |= file->language;
+        file = list.erase(file);
+    }
+}
+
 void gameDetails::filterWithPriorities(const gameSpecificConfig& config)
 {
     if (config.dlConf.vPlatformPriority.empty() && config.dlConf.vLanguagePriority.empty())
@@ -416,7 +501,7 @@ std::string gameDetails::makeFilepath(const gameFile& gf, const DirectoryConfig&
     return filepath;
 }
 
-std::string gameDetails::makeCustomFilepath(const std::string& filename, const gameDetails& gd, const DirectoryConfig& dirConf)
+std::string gameDetails::makeCustomFilepath(const std::string& filename, const gameDetails& gd, const DirectoryConfig& dirConf, const unsigned int& platform)
 {
     gameFile gf;
     gf.gamename = gd.gamename;
@@ -424,6 +509,7 @@ std::string gameDetails::makeCustomFilepath(const std::string& filename, const g
     gf.title = gd.title;
     gf.gamename_basegame = gd.gamename_basegame;
     gf.title_basegame = gd.title_basegame;
+    gf.platform = platform;
 
     if (gf.gamename_basegame.empty())
         gf.type = GlobalConstants::GFTYPE_CUSTOM_BASE;

--- a/src/obsolete.cpp
+++ b/src/obsolete.cpp
@@ -1,0 +1,87 @@
+/* This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details. */
+
+#include "obsolete.h"
+
+#include <algorithm>
+#include <system_error>
+
+#include <boost/filesystem.hpp>
+
+std::string Obsolete::pathKey(const boost::filesystem::path& path)
+{
+    boost::filesystem::path normalized = boost::filesystem::absolute(path).lexically_normal();
+    while (normalized != normalized.root_path() && normalized.filename() == ".")
+        normalized = normalized.parent_path();
+    std::string key = normalized.generic_string();
+    const std::size_t root_length = normalized.root_path().generic_string().size();
+    while (key.size() > root_length && key.back() == '/')
+        key.pop_back();
+    return key;
+}
+
+bool Obsolete::isWithin(const boost::filesystem::path& root, const boost::filesystem::path& path)
+{
+    const std::string root_key = pathKey(root);
+    const std::string path_key = pathKey(path);
+    if (root_key == path_key)
+        return true;
+    return path_key.size() > root_key.size()
+        && path_key.compare(0, root_key.size(), root_key) == 0
+        && path_key[root_key.size()] == '/';
+}
+
+std::string Obsolete::relativeKey(const boost::filesystem::path& root, const boost::filesystem::path& path)
+{
+    const std::string root_key = pathKey(root);
+    const std::string path_key = pathKey(path);
+    if (!isWithin(root, path))
+        return path_key;
+    if (root_key == path_key)
+        return std::string();
+    return path_key.substr(root_key.size() + 1);
+}
+
+std::vector<boost::filesystem::path> Obsolete::collectCandidates(
+    const boost::filesystem::path& root,
+    const boost::regex& expression
+)
+{
+    std::vector<boost::filesystem::path> candidates;
+    if (!boost::filesystem::exists(root) || !boost::filesystem::is_directory(root))
+        return candidates;
+
+    boost::filesystem::recursive_directory_iterator end;
+    for (boost::filesystem::recursive_directory_iterator it(root); it != end; ++it)
+    {
+        boost::system::error_code ec;
+        if (!boost::filesystem::is_regular_file(it->path(), ec) || ec)
+            continue;
+
+        const std::string filepath = it->path().generic_string();
+        if (boost::regex_search(filepath, expression))
+            candidates.push_back(it->path());
+    }
+
+    std::sort(candidates.begin(), candidates.end());
+    return candidates;
+}
+
+std::vector<boost::filesystem::path> Obsolete::findObsolete(
+    const std::vector<boost::filesystem::path>& candidates,
+    const std::set<std::string>& selected,
+    const std::set<std::string>& current
+)
+{
+    std::vector<boost::filesystem::path> obsolete;
+    for (const auto& candidate : candidates)
+    {
+        const std::string key = pathKey(candidate);
+        if (selected.find(key) == selected.end() && current.find(key) == current.end())
+            obsolete.push_back(candidate);
+    }
+    return obsolete;
+}

--- a/tests/catalog_metadata_tests.cpp
+++ b/tests/catalog_metadata_tests.cpp
@@ -1,0 +1,161 @@
+/* This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details. */
+
+#include "catalogmetadata.h"
+#include "globalconstants.h"
+
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+
+static void expect(bool condition, const std::string& message)
+{
+    if (!condition)
+    {
+        std::cerr << "FAIL: " << message << std::endl;
+        failures++;
+    }
+}
+
+int main()
+{
+    using CatalogMetadata::ResolutionFailure;
+
+    Json::Value empty;
+    expect(CatalogMetadata::validateFileResolution(empty, "") == ResolutionFailure::EmptyResponse,
+           "empty response is incomplete metadata");
+
+    Json::Value missing(Json::objectValue);
+    expect(CatalogMetadata::validateFileResolution(missing, "game/setup.exe") == ResolutionFailure::MissingDownlink,
+           "missing downlink is incomplete metadata");
+    Json::Value malformed(Json::arrayValue);
+    expect(CatalogMetadata::validateFileResolution(malformed, "game/setup.exe") == ResolutionFailure::MalformedResponse,
+           "non-object response is incomplete metadata");
+
+    Json::Value response(Json::objectValue);
+    response["downlink"] = "https://cdn.example/game/setup.exe";
+    expect(CatalogMetadata::validateFileResolution(response, "") == ResolutionFailure::EmptyPath,
+           "empty resolved path is incomplete metadata");
+    expect(CatalogMetadata::validateFileResolution(response, "game/secure") == ResolutionFailure::InvalidPath,
+           "secure placeholder is incomplete metadata");
+    expect(CatalogMetadata::validateFileResolution(response, "game/SECUREX") == ResolutionFailure::InvalidPath,
+           "securex placeholder is rejected case-insensitively");
+    expect(CatalogMetadata::validateFileResolution(response, "game/setup.exe") == ResolutionFailure::None,
+           "valid downlink and path are complete metadata");
+
+    Json::Value product(Json::objectValue);
+    product["downloads"] = Json::Value(Json::objectValue);
+    product["downloads"]["installers"] = Json::Value(Json::arrayValue);
+    product["downloads"]["bonus_content"] = Json::Value(Json::arrayValue);
+    expect(CatalogMetadata::countMissingDownloadSections(
+               product,
+               GlobalConstants::GFTYPE_INSTALLER | GlobalConstants::GFTYPE_EXTRA
+           ) == 0,
+           "present empty download arrays are complete metadata");
+    product["downloads"].removeMember("installers");
+    expect(CatalogMetadata::countMissingDownloadSections(product, GlobalConstants::GFTYPE_INSTALLER) == 1,
+           "missing selected download section is incomplete metadata");
+    product.removeMember("downloads");
+    expect(CatalogMetadata::countMissingDownloadSections(product, GlobalConstants::GFTYPE_INSTALLER) == 1,
+           "missing downloads object is one metadata failure");
+    Json::Value malformed_product(Json::arrayValue);
+    expect(CatalogMetadata::countMissingDownloadSections(
+               malformed_product,
+               GlobalConstants::GFTYPE_INSTALLER
+           ) == 1,
+           "non-object product is incomplete metadata");
+    expect(!CatalogMetadata::hasCompleteDlcExpansion(malformed_product),
+           "non-object product cannot have complete DLC expansion");
+
+    Json::Value no_dlc(Json::objectValue);
+    expect(CatalogMetadata::hasCompleteDlcExpansion(no_dlc), "product without DLCs needs no expansion");
+    Json::Value with_dlc(Json::objectValue);
+    with_dlc["dlcs"] = Json::Value(Json::objectValue);
+    expect(!CatalogMetadata::hasCompleteDlcExpansion(with_dlc), "missing DLC expansion is incomplete metadata");
+    with_dlc["expanded_dlcs"] = Json::Value(Json::arrayValue);
+    expect(CatalogMetadata::hasCompleteDlcExpansion(with_dlc), "empty expanded DLC array is complete metadata");
+
+    Json::Value group(Json::objectValue);
+    group["count"] = 1;
+    group["total_size"] = 123;
+    group["os"] = "windows";
+    group["language"] = "en";
+    group["files"] = Json::Value(Json::arrayValue);
+    expect(!CatalogMetadata::hasCompleteDownloadGroup(group, true),
+           "advertised group without files is incomplete metadata");
+    group["files"].append(Json::Value(Json::objectValue));
+    expect(CatalogMetadata::hasCompleteDownloadGroup(group, true),
+           "advertised group with platform, language, and files is structurally complete");
+    group.removeMember("language");
+    expect(!CatalogMetadata::hasCompleteDownloadGroup(group, true),
+           "installer group without language is incomplete metadata");
+    expect(CatalogMetadata::hasCompleteDownloadGroup(group, false),
+           "extra group does not require platform or language");
+    group.removeMember("count");
+    expect(CatalogMetadata::hasCompleteDownloadGroup(group, false),
+           "group with files does not require an aggregate count");
+    group["files"] = Json::Value(Json::arrayValue);
+    expect(!CatalogMetadata::hasCompleteDownloadGroup(group, false),
+           "non-empty aggregate without files is incomplete metadata");
+    group["count"] = 0;
+    group["total_size"] = 0;
+    expect(CatalogMetadata::hasCompleteDownloadGroup(group, false),
+           "all-zero group without files is a valid empty placeholder");
+    expect(CatalogMetadata::isEmptyDownloadGroup(group), "all-zero group is an empty placeholder");
+    group["files"].append(Json::Value(Json::objectValue));
+    group["count"] = Json::Value();
+    expect(CatalogMetadata::isEmptyDownloadGroup(group),
+           "GOG placeholder with a null count and file-shaped stubs remains empty");
+    group["total_size"] = 123;
+    expect(!CatalogMetadata::isEmptyDownloadGroup(group),
+           "non-zero group is never an empty placeholder");
+
+    // GOG lists some groups for information only, with count and total_size zero but
+    // real file entries (upstream commit 209d831). isEmptyDownloadGroup must classify
+    // exactly the groups upstream skips: an absent or null aggregate reads as zero.
+    Json::Value informational(Json::objectValue);
+    informational["os"] = "windows";
+    informational["language"] = "english";
+    informational["total_size"] = 0;
+    informational["files"] = Json::Value(Json::arrayValue);
+    Json::Value real_file(Json::objectValue);
+    real_file["id"] = "en1installer0";
+    real_file["size"] = "734003200";
+    real_file["downlink"] = "https://api.example/downlink/real";
+    informational["files"].append(real_file);
+    expect(CatalogMetadata::hasCompleteDownloadGroup(informational, true),
+           "informational group with files and no count is complete metadata");
+    expect(CatalogMetadata::isEmptyDownloadGroup(informational),
+           "an installer group with no count is a placeholder by total_size alone");
+    informational.removeMember("total_size");
+    expect(CatalogMetadata::isEmptyDownloadGroup(informational),
+           "an absent total_size reads as zero, the way upstream coerces it");
+    informational["total_size"] = Json::Value();
+    expect(CatalogMetadata::isEmptyDownloadGroup(informational),
+           "a null total_size reads as zero, the way upstream coerces it");
+    informational["total_size"] = 734003200;
+    expect(!CatalogMetadata::isEmptyDownloadGroup(informational),
+           "a group with a real total size is never a placeholder");
+
+    Json::Value file(Json::objectValue);
+    file["downlink"] = "https://api.example/downlink/1";
+    file["size"] = "123";
+    expect(CatalogMetadata::hasCompleteFileEntry(file), "file with downlink and size is complete metadata");
+    file.removeMember("size");
+    expect(!CatalogMetadata::hasCompleteFileEntry(file), "file without size is incomplete metadata");
+
+    expect(CatalogMetadata::scalarString(Json::Value("123")) == "123",
+           "string identifier remains a string");
+    expect(CatalogMetadata::scalarString(Json::Value(123)) == "123",
+           "numeric identifier is preserved for ownership matching");
+    expect(CatalogMetadata::scalarString(Json::Value(Json::objectValue)).empty(),
+           "structured identifier is rejected safely");
+
+    if (failures == 0)
+        std::cout << "All catalog-metadata tests passed" << std::endl;
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/gamedetails_filter_tests.cpp
+++ b/tests/gamedetails_filter_tests.cpp
@@ -1,0 +1,165 @@
+/* This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details. */
+
+#include "gamedetails.h"
+#include "globals.h"
+
+#include <iostream>
+#include <string>
+
+// Defined in main.cpp, which this target does not link.
+namespace Globals
+{
+    GalaxyConfig galaxyConf;
+    Config globalConfig;
+    std::vector<std::string> vOwnedGamesIds;
+    std::atomic<bool> bWindowProgress (false);
+}
+
+static int failures = 0;
+
+static void expect(bool condition, const std::string& message)
+{
+    if (!condition)
+    {
+        std::cerr << "FAIL: " << message << std::endl;
+        failures++;
+    }
+}
+
+static gameFile installer(
+    const std::string& id,
+    const std::string& path,
+    const unsigned int platform,
+    const unsigned int language
+)
+{
+    gameFile file;
+    file.id = id;
+    file.path = path;
+    file.platform = platform;
+    file.language = language;
+    file.type = GlobalConstants::GFTYPE_BASE_INSTALLER;
+    return file;
+}
+
+int main()
+{
+    gameDetails game;
+    game.installers = {
+        installer("german", "shared/setup.sh", GlobalConstants::PLATFORM_LINUX, GlobalConstants::LANGUAGE_DE),
+        installer("mac", "mac/setup.pkg", GlobalConstants::PLATFORM_MAC, GlobalConstants::LANGUAGE_EN),
+        installer("english", "shared/setup.sh", GlobalConstants::PLATFORM_LINUX, GlobalConstants::LANGUAGE_EN),
+        installer("english-duplicate", "shared/setup.sh", GlobalConstants::PLATFORM_LINUX, GlobalConstants::LANGUAGE_EN)
+    };
+
+    gameFile extra;
+    extra.id = "manual";
+    extra.path = "manual.zip";
+    extra.platform = GlobalConstants::PLATFORM_MAC;
+    extra.language = GlobalConstants::LANGUAGE_DE;
+    extra.type = GlobalConstants::GFTYPE_BASE_EXTRA;
+    game.extras.push_back(extra);
+
+    gameDetails dlc;
+    dlc.installers = {
+        installer("dlc-german", "shared/dlc.sh", GlobalConstants::PLATFORM_LINUX, GlobalConstants::LANGUAGE_DE),
+        installer("dlc-english", "shared/dlc.sh", GlobalConstants::PLATFORM_LINUX, GlobalConstants::LANGUAGE_EN)
+    };
+    game.dlcs.push_back(dlc);
+
+    DownloadConfig config = {};
+    config.iInstallerPlatform = GlobalConstants::PLATFORM_LINUX;
+    config.iInstallerLanguage = GlobalConstants::LANGUAGE_EN;
+
+    game.filterWithPlatformLanguage(config);
+    game.filterDuplicates();
+
+    expect(game.installers.size() == 1, "only one selected base installer remains");
+    if (!game.installers.empty())
+        expect(game.installers[0].id == "english", "selected language donates the retained downlink");
+    expect(game.extras.size() == 1, "platform and language filters do not remove extras");
+    expect(game.dlcs.size() == 1, "DLC with a selected file remains");
+    if (!game.dlcs.empty())
+    {
+        expect(game.dlcs[0].installers.size() == 1, "DLC filtering and deduplication are recursive");
+        if (!game.dlcs[0].installers.empty())
+            expect(game.dlcs[0].installers[0].id == "dlc-english", "DLC retains the selected language downlink");
+    }
+
+    // A multi-language selection must keep language attribution on the file that
+    // survives deduplication, or the retained copy loses the languages it covers.
+    gameDetails multilang;
+    multilang.installers = {
+        installer("shared-en", "shared/setup.sh", GlobalConstants::PLATFORM_LINUX, GlobalConstants::LANGUAGE_EN),
+        installer("shared-de", "shared/setup.sh", GlobalConstants::PLATFORM_LINUX, GlobalConstants::LANGUAGE_DE)
+    };
+    gameFile shared_extra_en = extra;
+    shared_extra_en.id = "extra-en";
+    shared_extra_en.path = "manual.zip";
+    shared_extra_en.platform = GlobalConstants::PLATFORM_LINUX;
+    shared_extra_en.language = GlobalConstants::LANGUAGE_EN;
+    gameFile shared_extra_de = shared_extra_en;
+    shared_extra_de.id = "extra-de";
+    shared_extra_de.language = GlobalConstants::LANGUAGE_DE;
+    multilang.extras = {shared_extra_en, shared_extra_de};
+
+    DownloadConfig multilang_config = {};
+    multilang_config.iInstallerPlatform = GlobalConstants::PLATFORM_LINUX;
+    multilang_config.iInstallerLanguage = GlobalConstants::LANGUAGE_EN | GlobalConstants::LANGUAGE_DE;
+    multilang.filterWithPlatformLanguage(multilang_config);
+    multilang.filterDuplicates();
+
+    expect(multilang.installers.size() == 1, "duplicate paths collapse to one installer");
+    if (!multilang.installers.empty())
+        expect(multilang.installers[0].language
+                   == (GlobalConstants::LANGUAGE_EN | GlobalConstants::LANGUAGE_DE),
+               "the retained installer keeps every language that shared its path");
+    expect(multilang.extras.size() == 1, "duplicate paths collapse to one extra");
+    if (!multilang.extras.empty())
+        expect(multilang.extras[0].language == GlobalConstants::LANGUAGE_EN,
+               "extras do not accumulate language bits when deduplicated");
+
+    // filterDlcsWithInclude must reproduce exactly the two conditions galaxyAPI
+    // applies when it admits a DLC, so that details built from the whole catalog
+    // still yield the selection the user asked for.
+    gameDetails with_dlc;
+    gameDetails installer_only_dlc;
+    gameFile dlc_installer = installer("dlc-only", "dlc/setup.exe",
+        GlobalConstants::PLATFORM_WINDOWS, GlobalConstants::LANGUAGE_EN);
+    dlc_installer.type = GlobalConstants::GFTYPE_DLC_INSTALLER;
+    installer_only_dlc.installers = {dlc_installer};
+    with_dlc.dlcs.push_back(installer_only_dlc);
+
+    gameDetails no_dlc_selected = with_dlc;
+    no_dlc_selected.filterDlcsWithInclude(GlobalConstants::GFTYPE_BASE);
+    expect(no_dlc_selected.dlcs.empty(), "no DLC survives a selection that asks for no DLC type");
+
+    gameDetails wrong_section = with_dlc;
+    wrong_section.filterDlcsWithInclude(GlobalConstants::GFTYPE_DLC_EXTRA);
+    expect(wrong_section.dlcs.empty(), "a DLC with no file in a selected section is dropped");
+
+    gameDetails right_section = with_dlc;
+    right_section.filterDlcsWithInclude(GlobalConstants::GFTYPE_DLC_INSTALLER);
+    expect(right_section.dlcs.size() == 1, "a DLC with a file in a selected section is kept");
+
+    // makeCustomFilepath must keep resolving %platform% the way it did before it
+    // gained a platform parameter, or --check-orphans scans the wrong directory.
+    DirectoryConfig dirConf = {};
+    dirConf.sDirectory = "/games";
+    dirConf.sGameSubdir = "%platform%/%gamename%";
+    gameDetails custom;
+    custom.gamename = "somegame";
+    expect(custom.makeCustomFilepath("serials.txt", custom, dirConf) == "/games/windows/somegame/serials.txt",
+           "the default platform keeps %platform% resolving to windows");
+    expect(custom.makeCustomFilepath("serials.txt", custom, dirConf, GlobalConstants::PLATFORM_LINUX)
+               == "/games/linux/somegame/serials.txt",
+           "an explicit platform is honoured");
+
+    if (failures == 0)
+        std::cout << "All game-details filter tests passed" << std::endl;
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/obsolete_tests.cpp
+++ b/tests/obsolete_tests.cpp
@@ -1,0 +1,154 @@
+/* This program is free software. It comes without any warranty, to
+ * the extent permitted by applicable law. You can redistribute it
+ * and/or modify it under the terms of the Do What The Fuck You Want
+ * To Public License, Version 2, as published by Sam Hocevar. See
+ * http://www.wtfpl.net/ for more details. */
+
+#include "obsolete.h"
+
+#include <unistd.h>
+
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+#include <boost/regex.hpp>
+
+namespace fs = boost::filesystem;
+
+static int failures = 0;
+
+static void expect(bool condition, const std::string& message)
+{
+    if (!condition)
+    {
+        std::cerr << "FAIL: " << message << std::endl;
+        failures++;
+    }
+}
+
+static void touch(const fs::path& path)
+{
+    fs::create_directories(path.parent_path());
+    std::ofstream file(path.string());
+    file << "test";
+}
+
+int main()
+{
+    const fs::path root = fs::temp_directory_path()
+        / ("lgog-obsolete-tests-" + std::to_string(static_cast<long long>(getpid())));
+    fs::remove_all(root);
+    fs::create_directories(root);
+
+    try
+    {
+        const fs::path current_exe = root / "game/windows/setup_game_2.0.exe";
+        const fs::path current_bin = root / "game/windows/setup_game_2.0-1.bin";
+        const fs::path old_exe = root / "game/windows/setup_game_1.0.exe";
+        const fs::path old_bin = root / "game/windows/setup_game_1.0-1.bin";
+        const fs::path linux_installer = root / "game/linux/game_2_0.sh";
+        const fs::path mac_installer = root / "game/mac/game_2_0.pkg";
+        const fs::path patch = root / "game/windows/patch_game_1.0_to_2.0.exe";
+        const fs::path extra = root / "game/extras/manual.zip";
+        const fs::path x86_installer = root / "game/windows/setup_game_2.0_(32bit).exe";
+        const fs::path x64_installer = root / "game/windows/setup_game_2.0_(64bit).exe";
+        const fs::path dlc_installer = root / "game/dlc/expansion/setup_expansion_2.0.exe";
+        const fs::path language_installer = root / "game/windows/setup_game_2.0_german.exe";
+        const fs::path disc_image = root / "game/windows/game_bonus_disc.iso";
+        const fs::path metadata = root / "game/game-details.json";
+
+        for (const auto& path : {current_exe, current_bin, old_exe, old_bin, linux_installer,
+                                 mac_installer, patch, extra, x86_installer, x64_installer,
+                                 dlc_installer, language_installer, disc_image, metadata})
+            touch(path);
+
+        const boost::regex expression(".*\\.(zip|exe|bin|dmg|old|deb|tar\\.gz|pkg|sh|mp4|iso)$");
+        auto candidates = Obsolete::collectCandidates(root / "game", expression);
+        expect(candidates.size() == 13, "candidate scan excludes metadata and includes all installer formats");
+
+        std::set<std::string> selected = {
+            Obsolete::pathKey(current_exe),
+            Obsolete::pathKey(current_bin),
+            Obsolete::pathKey(linux_installer),
+            Obsolete::pathKey(extra),
+            Obsolete::pathKey(x86_installer),
+            Obsolete::pathKey(x64_installer),
+            Obsolete::pathKey(dlc_installer),
+            Obsolete::pathKey(disc_image)
+        };
+        // "selected" is what this run would download; "current_catalog" is everything
+        // GOG still offers. The patch stands for a type left out by --include: still
+        // advertised, therefore protected.
+        std::set<std::string> current_catalog = selected;
+        current_catalog.insert(Obsolete::pathKey(mac_installer));
+        current_catalog.insert(Obsolete::pathKey(language_installer));
+        current_catalog.insert(Obsolete::pathKey(patch));
+        auto obsolete = Obsolete::findObsolete(candidates, selected, current_catalog);
+        std::set<std::string> obsolete_keys;
+        for (const auto& path : obsolete)
+            obsolete_keys.insert(Obsolete::pathKey(path));
+
+        expect(obsolete.size() == 2, "only the superseded multipart family is obsolete");
+        expect(obsolete_keys.count(Obsolete::pathKey(old_exe)) == 1, "old executable is obsolete");
+        expect(obsolete_keys.count(Obsolete::pathKey(old_bin)) == 1, "old split payload is obsolete");
+        expect(obsolete_keys.count(Obsolete::pathKey(patch)) == 0,
+               "a file the current catalog still advertises is retained even when not selected for download");
+        expect(obsolete_keys.count(Obsolete::pathKey(current_bin)) == 0, "current split payload is retained");
+        expect(obsolete_keys.count(Obsolete::pathKey(x86_installer)) == 0, "current 32-bit alternative is retained");
+        expect(obsolete_keys.count(Obsolete::pathKey(x64_installer)) == 0, "current 64-bit alternative is retained");
+        expect(obsolete_keys.count(Obsolete::pathKey(dlc_installer)) == 0, "current DLC installer is retained");
+        expect(obsolete_keys.count(Obsolete::pathKey(mac_installer)) == 0, "current non-selected platform installer is retained");
+        expect(obsolete_keys.count(Obsolete::pathKey(language_installer)) == 0, "current non-selected language installer is retained");
+        expect(obsolete_keys.count(Obsolete::pathKey(disc_image)) == 0, "current ISO is retained");
+        expect(Obsolete::isWithin(root / "game", current_exe), "game file is inside its scan root");
+        const fs::path trailing_root((root / "game").generic_string() + "/");
+        expect(Obsolete::isWithin(trailing_root, current_exe), "trailing root separator does not reject a game file");
+        expect(Obsolete::pathKey(trailing_root) == Obsolete::pathKey(root / "game"), "path key ignores trailing separators");
+        expect(!Obsolete::isWithin(root / "gam", current_exe), "path prefix is not treated as a parent directory");
+        expect(!Obsolete::isWithin(root / "other", current_exe), "unrelated root does not own game file");
+        expect(Obsolete::relativeKey(root, current_exe) == "game/windows/setup_game_2.0.exe",
+               "relative key follows documented directory-relative blacklist format");
+        expect(Obsolete::relativeKey(root / "gam", current_exe) == Obsolete::pathKey(current_exe),
+               "relative key does not strip a mere path prefix");
+
+        // An empty catalog condemns everything, which is why Downloader::checkObsolete
+        // refuses to delete from a root the live catalog described no file for.
+        expect(Obsolete::findObsolete(candidates, {}, {}).size() == candidates.size(),
+               "an empty catalog marks every candidate obsolete");
+
+        // The scan must never leave the game root.
+        expect(Obsolete::collectCandidates(root / "missing", expression).empty(),
+               "a root that does not exist yields no candidates");
+        expect(Obsolete::collectCandidates(current_exe, expression).empty(),
+               "a regular file passed as a root yields no candidates");
+
+        const fs::path outside_dir = root / "outside";
+        const fs::path outside_file = outside_dir / "unrelated_setup.exe";
+        touch(outside_file);
+        boost::system::error_code symlink_ec;
+        fs::create_directory_symlink(outside_dir, root / "game" / "linked", symlink_ec);
+        if (!symlink_ec)
+        {
+            // Compare resolved paths: a candidate reached through the symlink is
+            // still lexically inside the root, so only canonical form can tell.
+            const fs::path outside_canonical = fs::canonical(outside_file);
+            for (const auto& candidate : Obsolete::collectCandidates(root / "game", expression))
+                expect(fs::canonical(candidate) != outside_canonical,
+                       "the scan does not follow a directory symlink out of the game root");
+        }
+    }
+    catch (...)
+    {
+        fs::remove_all(root);
+        throw;
+    }
+
+    fs::remove_all(root);
+    if (failures == 0)
+        std::cout << "All obsolete-file tests passed" << std::endl;
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Add `--check-obsolete` / `--delete-obsolete`

Updating a game leaves the superseded installer on disk. `--check-orphans` cannot find it: an
orphan is a file GOG never listed, a superseded installer is one GOG listed until the update
replaced it. Nothing currently reports those, so libraries accumulate old versions that are hard
to tell from split parts, architecture alternatives and DLCs by filename alone.

`--check-obsolete` resolves the current catalog and reports local files it no longer offers.
`--delete-obsolete` removes them. Comparison is on exact paths from the catalog, so multi-part
`.exe`/`.bin` sets, DLCs and edition alternatives never depend on parsing version numbers out of
filenames.

### Safety model

Deleting someone's only copy of a game is the failure that matters, so the protected set is
deliberately **wider** than the download selection: it is resolved for every platform, language and
file type regardless of `--platform`, `--language` and `--include`, the way `checkOrphans` widens
the same three before it deletes anything. Those options still choose what is downloaded and
verified. This is what makes the check slow — every variant costs a downlink resolution.

Deletion from a game directory additionally requires that every selected current file there exists
and matches its exact current size, plus a freshly computed checksum for installers, patches and
language packs. It is refused when:

- size or checksum metadata cannot be retrieved;
- the catalog listed no file at all for that directory;
- there is no selected current file to verify against;
- that game's metadata came back incomplete — the game is reported but never pruned, while the rest
  of the library is still checked.

An incomplete response is never read as evidence that a local file is obsolete. Blacklisted and
ignorelisted files are neither reported nor deleted, verification runs only for directories that
actually have candidates, and the check always uses live metadata rather than the `--use-cache` copy.

### Changes to shared code

The first commit touches `galaxyAPI::productInfoJsonToGameDetails` and
`fileJsonNodeToGameFileVector`, which every command uses, so it is worth being explicit:

- **Nothing downloads differently.** Entries that could not be resolved were skipped before and are
  skipped now. The predicates classify exactly the groups already skipped: `count` and `total_size`
  are read the way `asUInt()`/`asLargestUInt()` read them, so an absent or null aggregate still
  means zero, and groups listed for information only (209d831) are still skipped.
- **Request volume is unchanged.** Resolution is still one request per file; the transport retry in
  `Util::CurlHandleGetResponse`, including its deliberate no-retry on 403/404, is left alone.
- The only new output is `gameDetails::metadataFailures`, which no existing path reads.
- `makeCustomFilepath` gained a platform parameter. Its default is the value `gameFile`'s
  constructor supplies, so every existing caller resolves `%platform%` exactly as before — verified
  by compiling the old and new sources side by side and comparing output for each template.

### Known limitations

Two things the catalog cannot describe, so a local copy is reported as obsolete: files GOG lists for
information only, and files of a DLC the account no longer owns. Neither has a resolvable download
path.

A game is skipped entirely when `%version%` appears in one of its directory templates: the game root
has no version of its own, so it would span every version directory while the catalog paths inside it
are version specific, and anything left at a previous version's path would look obsolete. Since
`%version%` landed in master immediately before this branch, refusing seemed better than guessing.

Like `--check-orphans`, the scan assumes everything under a game directory is lgogdownloader's, so
`--subdir-galaxy-install` must not resolve to the same directory as `--subdir-game`. All of this is
documented in the README and man page, along with the exit status, which is non-zero if any game was
skipped or any directory refused.

### Tests

`tests/` covers the pure decision logic: the path arithmetic and set difference in `Obsolete`, the
structural predicates in `CatalogMetadata`, and the `gameDetails` filters. Each assertion that
guards a real property is verified by mutation — following directory symlinks out of a game root,
dropping the DLC include gate, removing the absent/null coercion, dropping the language merge
deduplication depends on, reverting the `makeCustomFilepath` default, and ignoring the
current-catalog protection are all caught.

Tests are opt-in through `BUILD_TESTS`, defaulting **off** so a packager's build is unchanged; CI
turns them on and runs `ctest`.

### Verification

Rebased on current master. Each of the three commits builds and tests clean on its own, with g++ and
clang++, with `USE_QT_GUI` on and off, and with zero new compiler warnings.

Exercised against a real account, read-only and scoped with `--game`: the widened resolution produced
no spurious metadata failures, planted stale files were reported correctly, and `--delete-obsolete`
refused to delete them because the selected current files were not present locally — naming each
missing file and exiting non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVJ8ih962xWuHQTRNjr1Sc
